### PR TITLE
Fix selection of default values

### DIFF
--- a/Sharprompt/Select.cs
+++ b/Sharprompt/Select.cs
@@ -35,7 +35,7 @@ namespace Sharprompt
 
                 int prevPage = -1;
                 var pageCount = (options.Count - 1) / _pageSize + 1;
-                // When the default selected option is not the first one, try to resolve which page we need to "jump" to.
+                // Only resolve the page number when the option is neither 0 nor negative.
                 int currentPage = (selectedIndex == 0  || selectedIndex == -1) ? 0 : GetPageFromIndex(options, selectedIndex);
 
                 while (true)
@@ -57,7 +57,7 @@ namespace Sharprompt
                         options = filteredOptions.Skip(currentPage * _pageSize)
                                                  .Take(_pageSize)
                                                  .ToArray();
-                        // The previous page is only -1 once.
+                        // Initially, we need to check for the default index. After moving the page or default index this becomes irrelevant.
                         selectedIndex = prevPage == -1 && selectedIndex != -1 ? FindDefaultIndex(options, _baseOptions[selectedIndex].Item) : 0;
 
                         prevPage = currentPage;


### PR DESCRIPTION
## Description
Default value selection was broken. Line 61 always defaulted the 'selectedIndex' variable to -1 when rendering a new page of options.

I also added a function to check which page the default value is on, so that it is always visible.
I also changed the default value selection. It no longer defaults to "None", it now always selects the first option.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

This issue can be reproduced by simply providing a default value. Nothing happens, no matter the type/struct.


**Test Configuration**:
* Hardware: Windows 7 Ultimate x64
* Toolchain: CMD

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
