### PR TITLE
Adding custom color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ var cities = Prompt.MultiSelect("Which cities would you like to visit?", new[] {
 Console.WriteLine($"You picked {string.Join(", ", options)}");
 ```
 
+## Custom Prompter
+```csharp
+Prompt.ColorSchema.Answer = ConsoleColor.DarkRed;
+Prompt.ColorSchema.Select = ConsoleColor.DarkCyan;
+Prompt.ColorSchema.DisabledOption = ConsoleColor.DarkGray;
+
+var name = Prompt.Input<string>("What's your name?");
+Console.WriteLine($"Hello, {name}!");
+```
+
 ## Platforms
 
 - Windows

--- a/Sharprompt/Confirm.cs
+++ b/Sharprompt/Confirm.cs
@@ -78,7 +78,7 @@ namespace Sharprompt
         private void FinishTemplate(ConsoleRenderer renderer, FinishTemplateModel model)
         {
             renderer.WriteMessage(model.Message);
-            renderer.Write(model.Result ? "Yes" : "No", ConsoleColor.Cyan);
+            renderer.Write(model.Result ? "Yes" : "No", Prompt.ColorSchema.Answer);
         }
 
         private class TemplateModel

--- a/Sharprompt/Input.cs
+++ b/Sharprompt/Input.cs
@@ -84,7 +84,7 @@ namespace Sharprompt
 
             if (model.Result != null)
             {
-                renderer.Write(model.Result.ToString(), ConsoleColor.Cyan);
+                renderer.Write(model.Result.ToString(), Prompt.ColorSchema.Answer);
             }
         }
 

--- a/Sharprompt/MultiSelect.cs
+++ b/Sharprompt/MultiSelect.cs
@@ -192,7 +192,7 @@ namespace Sharprompt
             renderer.Write(model.Filter);
             if (_showConfirm && string.IsNullOrEmpty(model.Filter))
             {
-                renderer.Write(" Press Tab to confirm", ConsoleColor.Cyan);
+                renderer.Write(" Press Tab to confirm", Prompt.ColorSchema.Answer);
             }
 
             for (int i = 0; i < model.Options.Count; i++)
@@ -204,17 +204,17 @@ namespace Sharprompt
 
                 if (model.SelectedOptions.Contains(currentOption) && model.CurrentIndex != i && currentOption.Enabled)
                 {
-                    renderer.Write($"  {_arrowRight} ", ConsoleColor.Green);
+                    renderer.Write($"  {_arrowRight} ", Prompt.ColorSchema.Select);
                     renderer.Write($"{value}");
                 }
                 else if (model.CurrentIndex == i && currentOption.Enabled && !_disabledByLimit.Contains(currentOption))
                 {
-                    renderer.Write($"  {_arrowRight} {value}", ConsoleColor.Green);
+                    renderer.Write($"  {_arrowRight} {value}", Prompt.ColorSchema.Select);
                 }
                 // Check whether this option was disabled by default or whether it was disabled by the limiter
                 else if (!currentOption.Enabled || _disabledByLimit.Contains(currentOption))
                 {
-                    renderer.Write($"    {value} (disabled)", ConsoleColor.DarkCyan);
+                    renderer.Write($"    {value} (disabled)", Prompt.ColorSchema.DisabledOption);
                 }
                 else
                 {
@@ -228,7 +228,7 @@ namespace Sharprompt
         {
             renderer.WriteMessage(model.Message);
             string joined = string.Join(", ", model.SelectedOptions.Select(res => res.Value));
-            renderer.Write(joined, ConsoleColor.Cyan);
+            renderer.Write(joined, Prompt.ColorSchema.Answer);
         }
 
         private class TemplateModel

--- a/Sharprompt/Prompt.cs
+++ b/Sharprompt/Prompt.cs
@@ -28,5 +28,12 @@ namespace Sharprompt
         {
             return new MultiSelect<T>(message, items, limit, min, pageSize, valueSelector ?? (x => x.ToString())).Start();
         }
+
+        public static class ColorSchema
+        {
+            public static ConsoleColor Answer { get; set; } = ConsoleColor.Cyan;
+            public static ConsoleColor Select { get; set; } = ConsoleColor.Green;
+            public static ConsoleColor DisabledOption { get; set; } = ConsoleColor.DarkCyan;
+        }
     }
 }

--- a/Sharprompt/Select.cs
+++ b/Sharprompt/Select.cs
@@ -186,7 +186,7 @@ namespace Sharprompt
 
                 if (model.SelectedIndex == i)
                 {
-                    renderer.Write($"> {value}", ConsoleColor.Green);
+                    renderer.Write($"> {value}", Prompt.ColorSchema.Select);
                 }
                 else
                 {
@@ -198,7 +198,7 @@ namespace Sharprompt
         private void FinishTemplate(ConsoleRenderer renderer, FinishTemplateModel model)
         {
             renderer.WriteMessage(model.Message);
-            renderer.Write(model.Options[model.SelectedIndex].Value, ConsoleColor.Cyan);
+            renderer.Write(model.Options[model.SelectedIndex].Value, Prompt.ColorSchema.Answer);
         }
 
         private class TemplateModel


### PR DESCRIPTION
This PR implements support for custom colors. (#30)

To achieve this I wrote a `Prompter` class to allow for customization. A default prompter is automatically set up inside the `Prompt` class to keep the API backwards compatible.

A new class `ColorSchema` can be used to setup a custom propter (at the moment only colors can be changes, but it's possible to expand on the non-static `Prompter` class to customize other settings.

I also updated the `README.md` to reflect the changes.

If you want me to make changes, just let me know ^^