### PR TITLE
Support cancellable prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ var cities = Prompt.MultiSelect("Which cities would you like to visit?", new[] {
 Console.WriteLine($"You picked {string.Join(", ", options)}");
 ```
 
+### Cancel prompts
+```csharp
+using (var tokenSource = new CancellationTokenSource(5000))
+{
+    var name = Prompt.Input<string>("What's your name? - Hurry up!", cancellationToken: tokenSource.Token);
+    Console.WriteLine($"Hello, {name}!");
+}
+```
+
 ## Platforms
 
 - Windows

--- a/Sharprompt/Confirm.cs
+++ b/Sharprompt/Confirm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Sharprompt
 {
@@ -13,8 +14,10 @@ namespace Sharprompt
         private readonly string _message;
         private readonly bool? _defaultValue;
 
-        public bool Start()
+        public bool Start(CancellationToken? cancellationToken = null)
         {
+            var token = cancellationToken ?? CancellationToken.None;
+
             using (var scope = new ConsoleScope())
             {
                 bool result;
@@ -23,7 +26,7 @@ namespace Sharprompt
                 {
                     scope.Render(Template, new TemplateModel { Message = _message, DefaultValue = _defaultValue });
 
-                    var input = scope.ReadLine();
+                    var input = scope.ReadLine(token);
 
                     if (string.IsNullOrEmpty(input))
                     {

--- a/Sharprompt/Input.cs
+++ b/Sharprompt/Input.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Sharprompt
 {
@@ -20,8 +21,10 @@ namespace Sharprompt
         private readonly Type _targetType;
         private readonly Type _underlyingType;
 
-        public T Start()
+        public T Start(CancellationToken? cancellationToken = null)
         {
+            var token = cancellationToken ?? CancellationToken.None;
+
             using (var scope = new ConsoleScope())
             {
                 T result;
@@ -30,7 +33,7 @@ namespace Sharprompt
                 {
                     scope.Render(Template, new TemplateModel { Message = _message, DefaultValue = _defaultValue });
 
-                    var input = scope.ReadLine();
+                    var input = scope.ReadLine(token);
 
                     if (!scope.Validate(input, _validators))
                     {

--- a/Sharprompt/MultiSelect.cs
+++ b/Sharprompt/MultiSelect.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Sharprompt
 {
@@ -40,8 +41,10 @@ namespace Sharprompt
             return (bool)boxed;
         }
 
-        public IEnumerable<T> Start()
+        public IEnumerable<T> Start(CancellationToken? cancellationToken = null)
         {
+            var token = cancellationToken ?? CancellationToken.None;
+
             using (var scope = new ConsoleScope(false))
             {
                 // Defaults
@@ -78,7 +81,7 @@ namespace Sharprompt
 
                     scope.Render(Template, new TemplateModel { Message = _message, Filter = filter, SelectedOptions = selectedOptions, Options = _options, CurrentIndex = currentIndex });
 
-                    var keyInfo = scope.ReadKey();
+                    var keyInfo = scope.ReadKey(token);
 
                     if (keyInfo.Key == ConsoleKey.Enter)
                     {

--- a/Sharprompt/Password.cs
+++ b/Sharprompt/Password.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Sharprompt
 {
@@ -14,8 +15,10 @@ namespace Sharprompt
         private readonly string _message;
         private readonly IList<Func<object, ValidationError>> _validators;
 
-        public string Start()
+        public string Start(CancellationToken? cancellationToken = null)
         {
+            var token = cancellationToken ?? CancellationToken.None;
+
             using (var scope = new ConsoleScope())
             {
                 var result = "";
@@ -24,7 +27,7 @@ namespace Sharprompt
                 {
                     scope.Render(Template, new TemplateModel { Message = _message, InputLength = result.Length });
 
-                    var keyInfo = scope.ReadKey();
+                    var keyInfo = scope.ReadKey(token);
 
                     if (keyInfo.Key == ConsoleKey.Enter)
                     {

--- a/Sharprompt/Prompt.cs
+++ b/Sharprompt/Prompt.cs
@@ -1,32 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Sharprompt
 {
     public static class Prompt
     {
-        public static T Input<T>(string message, object defaultValue = null, IList<Func<object, ValidationError>> validators = null)
+        public static T Input<T>(string message, object defaultValue = null, IList<Func<object, ValidationError>> validators = null, CancellationToken? cancellationToken = null)
         {
-            return new Input<T>(message, defaultValue, validators).Start();
+            return new Input<T>(message, defaultValue, validators).Start(cancellationToken);
         }
 
-        public static string Password(string message, IList<Func<object, ValidationError>> validators = null)
+        public static string Password(string message, IList<Func<object, ValidationError>> validators = null, CancellationToken? cancellationToken = null)
         {
-            return new Password(message, validators).Start();
+            return new Password(message, validators).Start(cancellationToken);
         }
 
-        public static bool Confirm(string message, bool? defaultValue = null)
+        public static bool Confirm(string message, bool? defaultValue = null, CancellationToken? cancellationToken = null)
         {
-            return new Confirm(message, defaultValue).Start();
+            return new Confirm(message, defaultValue).Start(cancellationToken);
         }
 
-        public static T Select<T>(string message, IEnumerable<T> items, object defaultValue = null, int pageSize = 10, Func<T, string> valueSelector = null)
+        public static T Select<T>(string message, IEnumerable<T> items, object defaultValue = null, int pageSize = 10, Func<T, string> valueSelector = null, CancellationToken? cancellationToken = null)
         {
-            return new Select<T>(message, items, defaultValue, pageSize, valueSelector ?? (x => x.ToString())).Start();
+            return new Select<T>(message, items, defaultValue, pageSize, valueSelector ?? (x => x.ToString())).Start(cancellationToken);
         }
-        public static IEnumerable<T> MultiSelect<T>(string message, IEnumerable<T> items, object defaultValue = null, int pageSize = 10, int limit = -1, int min = 1, Func<T, string> valueSelector = null)
+        public static IEnumerable<T> MultiSelect<T>(string message, IEnumerable<T> items, object defaultValue = null, int pageSize = 10, int limit = -1, int min = 1, Func<T, string> valueSelector = null, CancellationToken? cancellationToken = null)
         {
-            return new MultiSelect<T>(message, items, limit, min, pageSize, valueSelector ?? (x => x.ToString())).Start();
+            return new MultiSelect<T>(message, items, limit, min, pageSize, valueSelector ?? (x => x.ToString())).Start(cancellationToken);
         }
     }
 }

--- a/Sharprompt/Select.cs
+++ b/Sharprompt/Select.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Sharprompt
 {
@@ -21,8 +22,10 @@ namespace Sharprompt
         private readonly int _pageSize;
         private readonly Func<string, string, bool> _filtering;
 
-        public T Start()
+        public T Start(CancellationToken? cancellationToken = null)
         {
+            var token = cancellationToken ?? CancellationToken.None;
+
             using (var scope = new ConsoleScope(false))
             {
                 var options = _baseOptions;
@@ -65,7 +68,7 @@ namespace Sharprompt
 
                     scope.Render(Template, new TemplateModel { Message = _message, Filter = filter, SelectedIndex = selectedIndex, Options = options });
 
-                    var keyInfo = scope.ReadKey();
+                    var keyInfo = scope.ReadKey(token);
 
                     if (keyInfo.Key == ConsoleKey.Enter)
                     {


### PR DESCRIPTION
This PR adds support for cancellable prompts (#33)

The most important changes happened in `ConsoleScope.cs` (all the other changes just pass through the CancellationToken to this class).

I implemented a new method called `CancellableFunction<T>` which basically wraps a function and also takes a cancel action and a cancellation token. If the token is marked as canceled the cancel action is called (which is responsible for cancelling the function) and an `OperationCanceledException` is raised, if the token is not canceled the function is executed and the result returned.

During my research I tried a few different options for cancelling the input methods I found here:
https://stackoverflow.com/questions/9479573/how-to-interrupt-console-readline

After digging a little deeper I found a way better way the the suggested "hacky" solutions here:
https://www.meziantou.net/cancelling-console-read.htm

The cancellation is now implemented using the [CancelIoEx WinAPI](https://docs.microsoft.com/en-us/windows/win32/fileio/cancelioex-func) which is intended for that purpose (cancelling IO)

Let me know what you think about it and if you need me to make any changes.