### PR TITLE
Fixed Prompt.Confirm default value message

### DIFF
--- a/Sharprompt/Forms/Confirm.cs
+++ b/Sharprompt/Forms/Confirm.cs
@@ -57,9 +57,13 @@ namespace Sharprompt.Forms
         {
             screenBuffer.WriteMessage(_message);
 
-            if (_defaultValue != null)
+            if (_defaultValue == null)
             {
-                screenBuffer.Write($"({(_defaultValue.Value ? "yes" : "no")}) ");
+                screenBuffer.Write("(y/n) ");
+            }
+            else if (_defaultValue.Value)
+            {
+                screenBuffer.Write("(Y/n) ");
             }
             else
             {


### PR DESCRIPTION
Close #87 

- (y/N) = default value is `false`
- (Y/n) = default value is `true`
- (y/n) = not default value (required input)