### PR TITLE
Improve default beep noise

### DIFF
--- a/Sharprompt/Drivers/DefaultConsoleDriver.cs
+++ b/Sharprompt/Drivers/DefaultConsoleDriver.cs
@@ -41,7 +41,7 @@ namespace Sharprompt.Drivers
 
         #region IConsoleDriver
 
-        public virtual void Beep() => Console.Beep();
+        public virtual void Beep() => Console.Write("\a");
 
         public void Reset()
         {


### PR DESCRIPTION
The current Beep method uses Console.Beep() which is quite loud and has scared me several times while using headphones. I have changed the beep to a "nicer" sound that sounds like Windows and is more user friendly :) 