### PR TITLE
Add delete functionality to List prompt

### DIFF
--- a/Sharprompt/Forms/ListForm.cs
+++ b/Sharprompt/Forms/ListForm.cs
@@ -103,16 +103,17 @@ namespace Sharprompt.Forms
                     case ConsoleKey.Delete when _startIndex < _inputBuffer.Length:
                         _inputBuffer.Remove(_startIndex, 1);
                         break;
-                    case ConsoleKey.LeftArrow:
-                    case ConsoleKey.RightArrow:
-                    case ConsoleKey.Backspace:
-                        ConsoleDriver.Beep();
-                        break;
-                    case ConsoleKey.Delete:
+                    case ConsoleKey.Delete when (keyInfo.Modifiers & ConsoleModifiers.Control) == ConsoleModifiers.Control:
                         if (_inputItems.Any())
                         {
                             _inputItems.RemoveAt(_inputItems.Count - 1);
                         }
+                        break;
+                    case ConsoleKey.LeftArrow:
+                    case ConsoleKey.RightArrow:
+                    case ConsoleKey.Backspace:
+                    case ConsoleKey.Delete:
+                        ConsoleDriver.Beep();
                         break;
                     default:
                         if (!char.IsControl(keyInfo.KeyChar))

--- a/Sharprompt/Forms/ListForm.cs
+++ b/Sharprompt/Forms/ListForm.cs
@@ -106,8 +106,13 @@ namespace Sharprompt.Forms
                     case ConsoleKey.LeftArrow:
                     case ConsoleKey.RightArrow:
                     case ConsoleKey.Backspace:
-                    case ConsoleKey.Delete:
                         ConsoleDriver.Beep();
+                        break;
+                    case ConsoleKey.Delete:
+                        if (_inputItems.Any())
+                        {
+                            _inputItems.RemoveAt(_inputItems.Count - 1);
+                        }
                         break;
                     default:
                         if (!char.IsControl(keyInfo.KeyChar))

--- a/Sharprompt/Forms/ListForm.cs
+++ b/Sharprompt/Forms/ListForm.cs
@@ -103,7 +103,7 @@ namespace Sharprompt.Forms
                     case ConsoleKey.Delete when _startIndex < _inputBuffer.Length:
                         _inputBuffer.Remove(_startIndex, 1);
                         break;
-                    case ConsoleKey.Delete when (keyInfo.Modifiers & ConsoleModifiers.Control) == ConsoleModifiers.Control:
+                    case ConsoleKey.Delete when keyInfo.Modifiers == ConsoleModifiers.Control:
                         if (_inputItems.Any())
                         {
                             _inputItems.RemoveAt(_inputItems.Count - 1);


### PR DESCRIPTION
After trying out the List command, I realized there was no way to modify/delete the list once a value has been entered. I figured the Delete key could be a nice option to allow users to delete their most recent entry added to their list.