### PR TITLE
Adding `ThrowExceptionOnCancel` global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,7 @@ var name = Prompt.Input<string>("What's your name?");
 Console.WriteLine($"Hello, {name}!");
 ```
 
-### Unicode Support
-
-![unicode](https://user-images.githubusercontent.com/1356444/89803983-86a3f900-db6e-11ea-8fc8-5b6f9ef5644f.gif)
+### Unicode support
 
 ```csharp
 // Prefer UTF-8 as the output encoding
@@ -164,6 +162,25 @@ Console.OutputEncoding = Encoding.UTF8;
 
 var name = Prompt.Input<string>("What's your name?");
 Console.WriteLine($"Hello, {name}!");
+```
+
+![unicode](https://user-images.githubusercontent.com/1356444/89803983-86a3f900-db6e-11ea-8fc8-5b6f9ef5644f.gif)
+
+### Cancellation support
+
+```csharp
+// Throw an exception when canceling with Ctrl-C
+Prompt.ThrowExceptionOnCancel = true;
+
+try
+{
+    var name = Prompt.Input<string>("What's your name?");
+    Console.WriteLine($"Hello, {name}!");
+}
+catch (PromptCanceledException ex)
+{
+    Console.WriteLine("Prompt canceled");
+}
 ```
 
 ## Supported platforms

--- a/Sharprompt/Drivers/DefaultConsoleDriver.cs
+++ b/Sharprompt/Drivers/DefaultConsoleDriver.cs
@@ -9,6 +9,8 @@ namespace Sharprompt.Drivers
     {
         static DefaultConsoleDriver()
         {
+            Console.TreatControlCAsInput = true;
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 var hConsole = NativeMethods.GetStdHandle(NativeMethods.STD_OUTPUT_HANDLE);
@@ -22,18 +24,11 @@ namespace Sharprompt.Drivers
             }
         }
 
-        public DefaultConsoleDriver()
-        {
-            Console.CancelKeyPress += CancelKeyPressHandler;
-        }
-
         #region IDisposable
 
         public void Dispose()
         {
             Reset();
-
-            Console.CancelKeyPress -= CancelKeyPressHandler;
         }
 
         #endregion
@@ -55,7 +50,17 @@ namespace Sharprompt.Drivers
             Console.Write("\x1b[2K");
         }
 
-        public ConsoleKeyInfo ReadKey() => Console.ReadKey(true);
+        public ConsoleKeyInfo ReadKey()
+        {
+            var keyInfo = Console.ReadKey(true);
+
+            if (keyInfo.Key == ConsoleKey.C && keyInfo.Modifiers == ConsoleModifiers.Control)
+            {
+                RequestCancellation?.Invoke();
+            }
+
+            return keyInfo;
+        }
 
         public void Write(string value, ConsoleColor color)
         {
@@ -87,7 +92,5 @@ namespace Sharprompt.Drivers
         public Action RequestCancellation { get; set; }
 
         #endregion
-
-        private void CancelKeyPressHandler(object sender, ConsoleCancelEventArgs e) => RequestCancellation?.Invoke();
     }
 }

--- a/Sharprompt/Drivers/DefaultConsoleDriver.cs
+++ b/Sharprompt/Drivers/DefaultConsoleDriver.cs
@@ -56,7 +56,7 @@ namespace Sharprompt.Drivers
 
             if (keyInfo.Key == ConsoleKey.C && keyInfo.Modifiers == ConsoleModifiers.Control)
             {
-                RequestCancellation?.Invoke();
+                CancellationCallback?.Invoke();
             }
 
             return keyInfo;
@@ -89,7 +89,7 @@ namespace Sharprompt.Drivers
 
         public int BufferHeight => Console.BufferHeight;
 
-        public Action RequestCancellation { get; set; }
+        public Action CancellationCallback { get; set; }
 
         #endregion
     }

--- a/Sharprompt/Drivers/IConsoleDriver.cs
+++ b/Sharprompt/Drivers/IConsoleDriver.cs
@@ -17,6 +17,6 @@ namespace Sharprompt.Drivers
         int CursorTop { get; }
         int BufferWidth { get; }
         int BufferHeight { get; }
-        Action RequestCancellation { get; set; }
+        Action CancellationCallback { get; set; }
     }
 }

--- a/Sharprompt/Forms/FormBase.cs
+++ b/Sharprompt/Forms/FormBase.cs
@@ -11,7 +11,10 @@ namespace Sharprompt.Forms
     {
         protected FormBase()
         {
-            ConsoleDriver = new DefaultConsoleDriver();
+            ConsoleDriver = new DefaultConsoleDriver
+            {
+                RequestCancellation = RequestCancellation
+            };
 
             _formRenderer = new FormRenderer(ConsoleDriver);
         }
@@ -66,6 +69,18 @@ namespace Sharprompt.Forms
             }
 
             return true;
+        }
+
+        private void RequestCancellation()
+        {
+            _formRenderer.Cancel();
+
+            if (Prompt.ThrowExceptionOnCancel)
+            {
+                throw new PromptCanceledException();
+            }
+
+            Environment.Exit(1);
         }
     }
 }

--- a/Sharprompt/Forms/FormBase.cs
+++ b/Sharprompt/Forms/FormBase.cs
@@ -77,7 +77,7 @@ namespace Sharprompt.Forms
 
             if (Prompt.ThrowExceptionOnCancel)
             {
-                throw new PromptCanceledException();
+                throw new PromptCanceledException("The prompt was canceled.", GetType().Name);
             }
 
             Environment.Exit(1);

--- a/Sharprompt/Forms/FormBase.cs
+++ b/Sharprompt/Forms/FormBase.cs
@@ -13,7 +13,7 @@ namespace Sharprompt.Forms
         {
             ConsoleDriver = new DefaultConsoleDriver
             {
-                RequestCancellation = RequestCancellation
+                CancellationCallback = CancellationHandler
             };
 
             _formRenderer = new FormRenderer(ConsoleDriver);
@@ -50,9 +50,9 @@ namespace Sharprompt.Forms
 
         protected void SetError(string errorMessage) => _formRenderer.ErrorMessage = errorMessage;
 
-        protected void SetError(ValidationResult validationResult) => _formRenderer.ErrorMessage = validationResult.ErrorMessage;
+        protected void SetError(Exception exception) => SetError(exception.Message);
 
-        protected void SetError(Exception exception) => _formRenderer.ErrorMessage = exception.Message;
+        protected void SetError(ValidationResult validationResult) => SetError(validationResult.ErrorMessage);
 
         protected bool TryValidate(object input, IList<Func<object, ValidationResult>> validators)
         {
@@ -71,7 +71,7 @@ namespace Sharprompt.Forms
             return true;
         }
 
-        private void RequestCancellation()
+        private void CancellationHandler()
         {
             _formRenderer.Cancel();
 

--- a/Sharprompt/Forms/FormRenderer.cs
+++ b/Sharprompt/Forms/FormRenderer.cs
@@ -9,6 +9,8 @@ namespace Sharprompt.Forms
     {
         public FormRenderer(IConsoleDriver consoleDriver)
         {
+            consoleDriver.RequestCancellation = RequestCancellation;
+
             _offscreenBuffer = new OffscreenBuffer(consoleDriver);
         }
 
@@ -41,6 +43,18 @@ namespace Sharprompt.Forms
 
                 _offscreenBuffer.WriteLine();
             }
+        }
+
+        private void RequestCancellation()
+        {
+            _offscreenBuffer.Cancel();
+
+            if (Prompt.ThrowExceptionOnCancel)
+            {
+                throw new PromptCanceledException();
+            }
+
+            Environment.Exit(1);
         }
     }
 }

--- a/Sharprompt/Forms/FormRenderer.cs
+++ b/Sharprompt/Forms/FormRenderer.cs
@@ -9,8 +9,6 @@ namespace Sharprompt.Forms
     {
         public FormRenderer(IConsoleDriver consoleDriver)
         {
-            consoleDriver.RequestCancellation = RequestCancellation;
-
             _offscreenBuffer = new OffscreenBuffer(consoleDriver);
         }
 
@@ -19,6 +17,8 @@ namespace Sharprompt.Forms
         public string ErrorMessage { get; set; }
 
         public void Dispose() => _offscreenBuffer.Dispose();
+
+        public void Cancel() => _offscreenBuffer.Cancel();
 
         public void Render(Action<OffscreenBuffer> template)
         {
@@ -43,18 +43,6 @@ namespace Sharprompt.Forms
 
                 _offscreenBuffer.WriteLine();
             }
-        }
-
-        private void RequestCancellation()
-        {
-            _offscreenBuffer.Cancel();
-
-            if (Prompt.ThrowExceptionOnCancel)
-            {
-                throw new PromptCanceledException();
-            }
-
-            Environment.Exit(1);
         }
     }
 }

--- a/Sharprompt/Internal/OffscreenBuffer.cs
+++ b/Sharprompt/Internal/OffscreenBuffer.cs
@@ -132,10 +132,7 @@ namespace Sharprompt.Internal
             _consoleDriver.Reset();
             _consoleDriver.SetCursorPosition(0, _cursorBottom);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                _consoleDriver.WriteLine();
-            }
+            _consoleDriver.WriteLine();
         }
 
         private class TextInfo

--- a/Sharprompt/Internal/OffscreenBuffer.cs
+++ b/Sharprompt/Internal/OffscreenBuffer.cs
@@ -14,7 +14,6 @@ namespace Sharprompt.Internal
             _consoleDriver = consoleDriver;
 
             _cursorBottom = _consoleDriver.CursorTop;
-            _consoleDriver.RequestCancellation = RequestCancellation;
         }
 
         private readonly IConsoleDriver _consoleDriver;
@@ -128,7 +127,7 @@ namespace Sharprompt.Internal
             _pushedCursor = null;
         }
 
-        private void RequestCancellation()
+        public void Cancel()
         {
             _consoleDriver.Reset();
             _consoleDriver.SetCursorPosition(0, _cursorBottom);
@@ -137,8 +136,6 @@ namespace Sharprompt.Internal
             {
                 _consoleDriver.WriteLine();
             }
-
-            Environment.Exit(1);
         }
 
         private class TextInfo

--- a/Sharprompt/Prompt.Customize.cs
+++ b/Sharprompt/Prompt.Customize.cs
@@ -4,6 +4,8 @@ namespace Sharprompt
 {
     public static partial class Prompt
     {
+        public static bool ThrowExceptionOnCancel { get; set; } = false;
+
         public static class ColorSchema
         {
             public static ConsoleColor DoneSymbol { get; set; } = ConsoleColor.Green;

--- a/Sharprompt/PromptCanceledException.cs
+++ b/Sharprompt/PromptCanceledException.cs
@@ -20,6 +20,12 @@ namespace Sharprompt
         {
         }
 
+        public PromptCanceledException(string message, string promptType)
+            : base(message)
+        {
+            PromptType = promptType;
+        }
+
         protected PromptCanceledException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Sharprompt/PromptCanceledException.cs
+++ b/Sharprompt/PromptCanceledException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Sharprompt
+{
+    [Serializable]
+    public class PromptCanceledException : Exception
+    {
+        public PromptCanceledException()
+        {
+        }
+
+        public PromptCanceledException(string message)
+            : base(message)
+        {
+        }
+
+        public PromptCanceledException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected PromptCanceledException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Sharprompt/PromptCanceledException.cs
+++ b/Sharprompt/PromptCanceledException.cs
@@ -24,5 +24,7 @@ namespace Sharprompt
             : base(info, context)
         {
         }
+
+        public string PromptType { get; }
     }
 }


### PR DESCRIPTION
Close #144 

### Tasks

- [x] Add basic `ThrowExceptionOnCancel` behavior
- [x] Add metadata to `PromptCanceledException`
  - Prompt type
  - Message

### Example

```csharp
Prompt.ThrowExceptionOnCancel = true;

try
{
    var name = Prompt.Input<string>("What's your name?");

    Console.WriteLine($"Hello, {name}!");
}
catch (PromptCanceledException ex)
{
    Console.WriteLine("User cancelled");
}
```