### PR TITLE
Fixed failing example build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var name = Prompt.Input<string>("What's your name?");
 Console.WriteLine($"Hello, {name}!");
 
 // Password input
-var secret = Prompt.Password("Type new password", new[] { Validators.Required(), Validators.MinLength(8) });
+var secret = Prompt.Password("Type new password", validators: new[] { Validators.Required(), Validators.MinLength(8) });
 Console.WriteLine("Password OK");
 
 // Confirmation


### PR DESCRIPTION
The example was failing to build due to the following error: "Argument type 'System.Func<object,System.ComponentModel.DataAnnotations.ValidationResult>[]' is not assignable to parameter type 'string'"  so specified the argument name explicitly