### PR TITLE
Support navigating and deleting word-by-word with the Control key

### DIFF
--- a/Sharprompt.Tests/TextInputBufferTests.cs
+++ b/Sharprompt.Tests/TextInputBufferTests.cs
@@ -210,4 +210,96 @@ public class TextInputBufferTests
         Assert.Equal(backward, textInputBuffer.ToBackwardString());
         Assert.Equal(forward, textInputBuffer.ToForwardString());
     }
+
+    [Theory]
+    [InlineData("_abc", "", "abc")]
+    [InlineData("a_bc", "", "bc")]
+    [InlineData("abc_", "", "")]
+    [InlineData("_あいう", "", "あいう")]
+    [InlineData("あ_いう", "", "いう")]
+    [InlineData("あいう_", "", "")]
+    [InlineData("_𩸽𠈻𠮷", "", "𩸽𠈻𠮷")]
+    [InlineData("𩸽_𠈻𠮷", "", "𠈻𠮷")]
+    [InlineData("𩸽𠈻𠮷_", "", "")]
+    [InlineData("_🍣🍖🥂", "", "🍣🍖🥂")]
+    [InlineData("🍣_🍖🥂", "", "🍖🥂")]
+    [InlineData("🍣🍖🥂_", "", "")]
+    [InlineData("_aあ𩸽🍣", "", "aあ𩸽🍣")]
+    [InlineData("a_あ𩸽🍣", "", "あ𩸽🍣")]
+    [InlineData("aあ_𩸽🍣", "", "𩸽🍣")]
+    [InlineData("aあ𩸽_🍣", "", "🍣")]
+    [InlineData("aあ𩸽🍣_", "", "")]
+    [InlineData("_ abc def ", "", " abc def ")]
+    [InlineData(" _abc def ", "", "abc def ")]
+    [InlineData(" a_bc def ", " ", "bc def ")]
+    [InlineData(" abc_ def ", " ", " def ")]
+    [InlineData(" abc _def ", " ", "def ")]
+    [InlineData(" abc d_ef ", " abc ", "ef ")]
+    [InlineData(" abc def_ ", " abc ", " ")]
+    [InlineData(" abc def _", " abc ", "")]
+    public void BackspaceWord(string value, string backward, string forward)
+    {
+        var textInputBuffer = new TextInputBuffer();
+        var cursor = value.IndexOf('_');
+        foreach (var c in value[(cursor + 1)..])
+        {
+            textInputBuffer.Insert(c);
+        }
+        textInputBuffer.MoveToStart();
+        foreach (var c in value[..cursor])
+        {
+            textInputBuffer.Insert(c);
+        }
+
+        textInputBuffer.BackspaceWord();
+
+        Assert.Equal(backward, textInputBuffer.ToBackwardString());
+        Assert.Equal(forward, textInputBuffer.ToForwardString());
+    }
+
+    [Theory]
+    [InlineData("_abc", "", "")]
+    [InlineData("a_bc", "a", "")]
+    [InlineData("abc_", "abc", "")]
+    [InlineData("_あいう", "", "")]
+    [InlineData("あ_いう", "あ", "")]
+    [InlineData("あいう_", "あいう", "")]
+    [InlineData("_𩸽𠈻𠮷", "", "")]
+    [InlineData("𩸽_𠈻𠮷", "𩸽", "")]
+    [InlineData("𩸽𠈻𠮷_", "𩸽𠈻𠮷", "")]
+    [InlineData("_🍣🍖🥂", "", "")]
+    [InlineData("🍣_🍖🥂", "🍣", "")]
+    [InlineData("🍣🍖🥂_", "🍣🍖🥂", "")]
+    [InlineData("_aあ𩸽🍣", "", "")]
+    [InlineData("a_あ𩸽🍣", "a", "")]
+    [InlineData("aあ_𩸽🍣", "aあ", "")]
+    [InlineData("aあ𩸽_🍣", "aあ𩸽", "")]
+    [InlineData("aあ𩸽🍣_", "aあ𩸽🍣", "")]
+    [InlineData("_ abc def ", "", "abc def ")]
+    [InlineData(" _abc def ", " ", "def ")]
+    [InlineData(" a_bc def ", " a", "def ")]
+    [InlineData(" abc_ def ", " abc", "def ")]
+    [InlineData(" abc _def ", " abc ", "")]
+    [InlineData(" abc d_ef ", " abc d", "")]
+    [InlineData(" abc def_ ", " abc def", "")]
+    [InlineData(" abc def _", " abc def ", "")]
+    public void DeleteWord(string value, string backward, string forward)
+    {
+        var textInputBuffer = new TextInputBuffer();
+        var cursor = value.IndexOf('_');
+        foreach (var c in value[(cursor + 1)..])
+        {
+            textInputBuffer.Insert(c);
+        }
+        textInputBuffer.MoveToStart();
+        foreach (var c in value[..cursor])
+        {
+            textInputBuffer.Insert(c);
+        }
+
+        textInputBuffer.DeleteWord();
+
+        Assert.Equal(backward, textInputBuffer.ToBackwardString());
+        Assert.Equal(forward, textInputBuffer.ToForwardString());
+    }
 }

--- a/Sharprompt.Tests/TextInputBufferTests.cs
+++ b/Sharprompt.Tests/TextInputBufferTests.cs
@@ -66,10 +66,7 @@ public class TextInputBufferTests
             textInputBuffer.Insert(c);
         }
 
-        while (!textInputBuffer.IsStart)
-        {
-            textInputBuffer.MoveBackward();
-        }
+        textInputBuffer.MoveToStart();
 
         textInputBuffer.Delete();
 
@@ -114,12 +111,101 @@ public class TextInputBufferTests
             textInputBuffer.Insert(c);
         }
 
-        while (!textInputBuffer.IsStart)
-        {
-            textInputBuffer.MoveBackward();
-        }
+        textInputBuffer.MoveToStart();
 
         textInputBuffer.MoveForward();
+
+        Assert.Equal(backward, textInputBuffer.ToBackwardString());
+        Assert.Equal(forward, textInputBuffer.ToForwardString());
+    }
+
+    [Theory]
+    [InlineData("_abc", "", "abc")]
+    [InlineData("a_bc", "", "abc")]
+    [InlineData("abc_", "", "abc")]
+    [InlineData("_あいう", "", "あいう")]
+    [InlineData("あ_いう", "", "あいう")]
+    [InlineData("あいう_", "", "あいう")]
+    [InlineData("_𩸽𠈻𠮷", "", "𩸽𠈻𠮷")]
+    [InlineData("𩸽_𠈻𠮷", "", "𩸽𠈻𠮷")]
+    [InlineData("𩸽𠈻𠮷_", "", "𩸽𠈻𠮷")]
+    [InlineData("_🍣🍖🥂", "", "🍣🍖🥂")]
+    [InlineData("🍣_🍖🥂", "", "🍣🍖🥂")]
+    [InlineData("🍣🍖🥂_", "", "🍣🍖🥂")]
+    [InlineData("_aあ𩸽🍣", "", "aあ𩸽🍣")]
+    [InlineData("a_あ𩸽🍣", "", "aあ𩸽🍣")]
+    [InlineData("aあ_𩸽🍣", "", "aあ𩸽🍣")]
+    [InlineData("aあ𩸽_🍣", "", "aあ𩸽🍣")]
+    [InlineData("aあ𩸽🍣_", "", "aあ𩸽🍣")]
+    [InlineData("_ abc def ", "", " abc def ")]
+    [InlineData(" _abc def ", "", " abc def ")]
+    [InlineData(" a_bc def ", " ", "abc def ")]
+    [InlineData(" abc_ def ", " ", "abc def ")]
+    [InlineData(" abc _def ", " ", "abc def ")]
+    [InlineData(" abc d_ef ", " abc ", "def ")]
+    [InlineData(" abc def_ ", " abc ", "def ")]
+    [InlineData(" abc def _", " abc ", "def ")]
+    public void MoveToPreviousWord(string value, string backward, string forward)
+    {
+        var textInputBuffer = new TextInputBuffer();
+        var cursor = value.IndexOf('_');
+        foreach (var c in value[(cursor + 1)..])
+        {
+            textInputBuffer.Insert(c);
+        }
+        textInputBuffer.MoveToStart();
+        foreach (var c in value[..cursor])
+        {
+            textInputBuffer.Insert(c);
+        }
+
+        textInputBuffer.MoveToPreviousWord();
+
+        Assert.Equal(backward, textInputBuffer.ToBackwardString());
+        Assert.Equal(forward, textInputBuffer.ToForwardString());
+    }
+
+    [Theory]
+    [InlineData("_abc", "abc", "")]
+    [InlineData("a_bc", "abc", "")]
+    [InlineData("abc_", "abc", "")]
+    [InlineData("_あいう", "あいう", "")]
+    [InlineData("あ_いう", "あいう", "")]
+    [InlineData("あいう_", "あいう", "")]
+    [InlineData("_𩸽𠈻𠮷", "𩸽𠈻𠮷", "")]
+    [InlineData("𩸽_𠈻𠮷", "𩸽𠈻𠮷", "")]
+    [InlineData("𩸽𠈻𠮷_", "𩸽𠈻𠮷", "")]
+    [InlineData("_🍣🍖🥂", "🍣🍖🥂", "")]
+    [InlineData("🍣_🍖🥂", "🍣🍖🥂", "")]
+    [InlineData("🍣🍖🥂_", "🍣🍖🥂", "")]
+    [InlineData("_aあ𩸽🍣", "aあ𩸽🍣", "")]
+    [InlineData("a_あ𩸽🍣", "aあ𩸽🍣", "")]
+    [InlineData("aあ_𩸽🍣", "aあ𩸽🍣", "")]
+    [InlineData("aあ𩸽_🍣", "aあ𩸽🍣", "")]
+    [InlineData("aあ𩸽🍣_", "aあ𩸽🍣", "")]
+    [InlineData("_ abc def ", " ", "abc def ")]
+    [InlineData(" _abc def ", " abc ", "def ")]
+    [InlineData(" a_bc def ", " abc ", "def ")]
+    [InlineData(" abc_ def ", " abc ", "def ")]
+    [InlineData(" abc _def ", " abc def ", "")]
+    [InlineData(" abc d_ef ", " abc def ", "")]
+    [InlineData(" abc def_ ", " abc def ", "")]
+    [InlineData(" abc def _", " abc def ", "")]
+    public void MoveToNextWord(string value, string backward, string forward)
+    {
+        var textInputBuffer = new TextInputBuffer();
+        var cursor = value.IndexOf('_');
+        foreach (var c in value[(cursor + 1)..])
+        {
+            textInputBuffer.Insert(c);
+        }
+        textInputBuffer.MoveToStart();
+        foreach (var c in value[..cursor])
+        {
+            textInputBuffer.Insert(c);
+        }
+
+        textInputBuffer.MoveToNextWord();
 
         Assert.Equal(backward, textInputBuffer.ToBackwardString());
         Assert.Equal(forward, textInputBuffer.ToForwardString());

--- a/Sharprompt/Forms/InputForm.cs
+++ b/Sharprompt/Forms/InputForm.cs
@@ -26,11 +26,18 @@ internal class InputForm<T> : FormBase<T>
         do
         {
             var keyInfo = ConsoleDriver.ReadKey();
+            var controlPressed = keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control);
 
             switch (keyInfo.Key)
             {
                 case ConsoleKey.Enter:
                     return HandleEnter(out result);
+                case ConsoleKey.LeftArrow when controlPressed && !_textInputBuffer.IsStart:
+                    _textInputBuffer.MoveToPreviousWord();
+                    break;
+                case ConsoleKey.RightArrow when controlPressed && !_textInputBuffer.IsEnd:
+                    _textInputBuffer.MoveToNextWord();
+                    break;
                 case ConsoleKey.LeftArrow when !_textInputBuffer.IsStart:
                     _textInputBuffer.MoveBackward();
                     break;

--- a/Sharprompt/Forms/InputForm.cs
+++ b/Sharprompt/Forms/InputForm.cs
@@ -50,6 +50,12 @@ internal class InputForm<T> : FormBase<T>
                 case ConsoleKey.End when !_textInputBuffer.IsEnd:
                     _textInputBuffer.MoveToEnd();
                     break;
+                case ConsoleKey.Backspace when controlPressed && !_textInputBuffer.IsStart:
+                    _textInputBuffer.BackspaceWord();
+                    break;
+                case ConsoleKey.Delete when controlPressed && !_textInputBuffer.IsEnd:
+                    _textInputBuffer.DeleteWord();
+                    break;
                 case ConsoleKey.Backspace when !_textInputBuffer.IsStart:
                     _textInputBuffer.Backspace();
                     break;

--- a/Sharprompt/Internal/TextInputBuffer.cs
+++ b/Sharprompt/Internal/TextInputBuffer.cs
@@ -63,6 +63,32 @@ internal class TextInputBuffer
         }
     }
 
+    public void MoveToPreviousWord()
+    {
+        while (_position > 0 && char.IsWhiteSpace(_inputBuffer[_position - 1]))
+        {
+            _position--;
+        }
+
+        while (_position > 0 && !char.IsWhiteSpace(_inputBuffer[_position - 1]))
+        {
+            _position--;
+        }
+    }
+
+    public void MoveToNextWord()
+    {
+        while (_position < _inputBuffer.Length && !char.IsWhiteSpace(_inputBuffer[_position]))
+        {
+            _position++;
+        }
+
+        while (_position < _inputBuffer.Length && char.IsWhiteSpace(_inputBuffer[_position]))
+        {
+            _position++;
+        }
+    }
+
     public void MoveToStart() => _position = 0;
 
     public void MoveToEnd() => _position = _inputBuffer.Length;

--- a/Sharprompt/Internal/TextInputBuffer.cs
+++ b/Sharprompt/Internal/TextInputBuffer.cs
@@ -41,6 +41,42 @@ internal class TextInputBuffer
         _inputBuffer.Remove(_position, count);
     }
 
+    public void BackspaceWord()
+    {
+        var count = 0;
+
+        while (_position > 0 && char.IsWhiteSpace(_inputBuffer[_position - 1]))
+        {
+            _position--;
+            count++;
+        }
+
+        while (_position > 0 && !char.IsWhiteSpace(_inputBuffer[_position - 1]))
+        {
+            _position--;
+            count++;
+        }
+
+        _inputBuffer.Remove(_position, count);
+    }
+
+    public void DeleteWord()
+    {
+        var count = 0;
+
+        while (_position + count < _inputBuffer.Length && !char.IsWhiteSpace(_inputBuffer[_position + count]))
+        {
+            count++;
+        }
+
+        while (_position + count < _inputBuffer.Length && char.IsWhiteSpace(_inputBuffer[_position + count]))
+        {
+            count++;
+        }
+
+        _inputBuffer.Remove(_position, count);
+    }
+
     public void Clear()
     {
         _position = 0;


### PR DESCRIPTION
Fixes #222.

I've tried to match the behavior in the Windows Console and Windows Terminal, except for some edge cases if strings start with whitespace.

I do not know how word-by-word navigation usually works in non-alphabetic languages nor in right-to-left languages, so there may need to be some adjustments for those.

I considered rewriting all the tests to use the test case syntax with a `_` indicating the cursor position, but will let you decide if that's appropriate, @shibayan.

![A screen capture that shows navigating back and forth and deleting word-by-word](https://user-images.githubusercontent.com/984760/177579647-c448a17d-f3db-4245-8328-9eb768411bfe.gif)
