### PR TITLE
When placing the console cursor on a new line, write a newline to ensure it's initialized

### DIFF
--- a/Sharprompt/Internal/OffscreenBuffer.cs
+++ b/Sharprompt/Internal/OffscreenBuffer.cs
@@ -79,7 +79,18 @@ internal class OffscreenBuffer : IDisposable
             var physicalLeft = _pushedCursor.Left % _consoleDriver.BufferWidth;
             var physicalTop = _pushedCursor.Top + (_pushedCursor.Left / _consoleDriver.BufferWidth);
 
-            _consoleDriver.SetCursorPosition(physicalLeft, _cursorBottom - WrittenLineCount + physicalTop);
+            var consoleTop = _cursorBottom - WrittenLineCount + physicalTop;
+            if (_pushedCursor.Left > 0 && physicalLeft == 0)
+            {
+                _consoleDriver.WriteLine();
+                if (consoleTop == _consoleDriver.BufferHeight)
+                {
+                    _cursorBottom--;
+                    consoleTop--;
+                }
+            }
+
+            _consoleDriver.SetCursorPosition(physicalLeft, consoleTop);
         }
     }
 


### PR DESCRIPTION
Fixes #213 and an unreported issue that no cursor is shown when the console wraps to a new line.

@shibayan, I'm not sure if this is the fundamental fix that you wanted, but it does seem to do the trick.