### PR TITLE
Skip ReadOnly and BindIgnore Properties on Bind

### DIFF
--- a/Sharprompt.Example/Models/MyFormModel.cs
+++ b/Sharprompt.Example/Models/MyFormModel.cs
@@ -5,6 +5,12 @@ namespace Sharprompt.Example.Models;
 
 public class MyFormModel
 {
+    [Display(Name = "Id")]
+    [BindIgnore]
+    public int Id { get; set; }
+
+    public string ReadOnly { get; }
+
     [Display(Name = "What's your name?", Prompt = "Required", Order = 1)]
     [Required]
     public string Name { get; set; }

--- a/Sharprompt.Tests/PropertyMetadataTests.cs
+++ b/Sharprompt.Tests/PropertyMetadataTests.cs
@@ -177,6 +177,24 @@ public class PropertyMetadataTests
     }
 
     [Fact]
+    public void BindIgnore()
+    {
+        var metadata = PropertyMetadataFactory.Create(new BindIgnoreModel());
+
+        Assert.NotNull(metadata);
+        Assert.Equal(1, metadata.Count);
+    }
+
+    [Fact]
+    public void ReadOnly()
+    {
+        var metadata = PropertyMetadataFactory.Create(new ReadOnlyModel());
+
+        Assert.NotNull(metadata);
+        Assert.Equal(1, metadata.Count);
+    }
+
+    [Fact]
     public void MemberItems()
     {
         var metadata = PropertyMetadataFactory.Create(new MemberItemsModel());
@@ -252,6 +270,21 @@ public class PropertyMetadataTests
 
         [InlineItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
         public IEnumerable<int> IntArray { get; set; }
+    }
+
+    public class BindIgnoreModel
+    {
+        [BindIgnore]
+        public int IntValue { get; set; }
+
+        public string StringValue { get; set; }
+    }
+
+    public class ReadOnlyModel
+    {
+        public int IntValue { get; }
+
+        public string StringValue { get; set; }
     }
 
     public class MemberItemsModel

--- a/Sharprompt/BindIgnoreAttribute.cs
+++ b/Sharprompt/BindIgnoreAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Sharprompt;
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class BindIgnoreAttribute : Attribute
+{
+}

--- a/Sharprompt/Internal/PropertyMetadata.cs
+++ b/Sharprompt/Internal/PropertyMetadata.cs
@@ -31,6 +31,7 @@ internal class PropertyMetadata
                                  .Select(x => new ValidationAttributeAdapter(x).GetValidator(propertyInfo.Name, model))
                                  .ToArray();
         ItemsProvider = (IItemsProvider)propertyInfo.GetCustomAttribute<InlineItemsAttribute>(true) ?? propertyInfo.GetCustomAttribute<MemberItemsAttribute>(true);
+        BindIgnore = propertyInfo.GetCustomAttribute<BindIgnoreAttribute>() != null;
     }
 
     public PropertyInfo PropertyInfo { get; }
@@ -45,6 +46,7 @@ internal class PropertyMetadata
     public object DefaultValue { get; }
     public IReadOnlyList<Func<object, ValidationResult>> Validators { get; }
     public IItemsProvider ItemsProvider { get; set; }
+    public bool BindIgnore { get; set; }
 
     public FormType DetermineFormType()
     {

--- a/Sharprompt/Internal/PropertyMetadataFactory.cs
+++ b/Sharprompt/Internal/PropertyMetadataFactory.cs
@@ -9,7 +9,9 @@ internal static class PropertyMetadataFactory
     public static IReadOnlyList<PropertyMetadata> Create<T>(T model)
     {
         return typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                        .Where(x => x.CanWrite)
                         .Select(x => new PropertyMetadata(model, x))
+                        .Where(x => !x.BindIgnore)
                         .OrderBy(x => x.Order)
                         .ToArray();
     }


### PR DESCRIPTION
- Fix an issue when you try to bind a class with read-only properties
- Introduce BindIgnoreAttribute to ignore properties for binding