### PR TITLE
Fixed crash when displaying many items in `Prompt.Select` or `Prompt.MultiSelect`

### DIFF
--- a/Sharprompt/Drivers/DefaultConsoleDriver.cs
+++ b/Sharprompt/Drivers/DefaultConsoleDriver.cs
@@ -103,6 +103,10 @@ internal sealed class DefaultConsoleDriver : IConsoleDriver
 
     public int BufferHeight => Console.BufferHeight;
 
+    public int WindowWidth => Console.WindowWidth;
+
+    public int WindowHeight => Console.WindowHeight;
+
     public Action CancellationCallback { get; set; }
 
     #endregion

--- a/Sharprompt/Drivers/IConsoleDriver.cs
+++ b/Sharprompt/Drivers/IConsoleDriver.cs
@@ -17,5 +17,7 @@ internal interface IConsoleDriver : IDisposable
     int CursorTop { get; }
     int BufferWidth { get; }
     int BufferHeight { get; }
+    int WindowWidth { get; }
+    int WindowHeight { get; }
     Action CancellationCallback { get; set; }
 }

--- a/Sharprompt/Forms/MultiSelectForm.cs
+++ b/Sharprompt/Forms/MultiSelectForm.cs
@@ -15,7 +15,10 @@ internal class MultiSelectForm<T> : FormBase<IEnumerable<T>>
 
         _options = options;
 
-        _paginator = new Paginator<T>(options.Items, options.PageSize, Optional<T>.Empty, options.TextSelector);
+        var maxPageSize = ConsoleDriver.WindowHeight - 2;
+        var pageSize = Math.Min(options.PageSize ?? maxPageSize, maxPageSize);
+
+        _paginator = new Paginator<T>(options.Items, pageSize, Optional<T>.Empty, options.TextSelector);
 
         if (options.DefaultValues is not null)
         {

--- a/Sharprompt/Forms/SelectForm.cs
+++ b/Sharprompt/Forms/SelectForm.cs
@@ -14,7 +14,10 @@ internal class SelectForm<T> : FormBase<T>
 
         _options = options;
 
-        _paginator = new Paginator<T>(options.Items, options.PageSize, Optional<T>.Create(options.DefaultValue), options.TextSelector);
+        var maxPageSize = ConsoleDriver.WindowHeight - 2;
+        var pageSize = Math.Min(options.PageSize ?? maxPageSize, maxPageSize);
+
+        _paginator = new Paginator<T>(options.Items, pageSize, Optional<T>.Create(options.DefaultValue), options.TextSelector);
     }
 
     private readonly SelectOptions<T> _options;

--- a/Sharprompt/Internal/Paginator.cs
+++ b/Sharprompt/Internal/Paginator.cs
@@ -6,10 +6,10 @@ namespace Sharprompt.Internal;
 
 internal class Paginator<T>
 {
-    public Paginator(IEnumerable<T> items, int? pageSize, Optional<T> defaultValue, Func<T, string> textSelector)
+    public Paginator(IEnumerable<T> items, int pageSize, Optional<T> defaultValue, Func<T, string> textSelector)
     {
         _items = items.ToArray();
-        _pageSize = pageSize ?? _items.Length;
+        _pageSize = Math.Min(pageSize, _items.Length);
         _textSelector = textSelector;
 
         InitializeDefaults(defaultValue);


### PR DESCRIPTION
Avoid the problem by using `Prompt.Select` and `Prompt.MultiSelect` to limit the number of items that can be displayed on one screen to the window height.