### PR TITLE
refactor(Paginator): extract filtering of text input into Func

### DIFF
--- a/Sharprompt.Example/Program.cs
+++ b/Sharprompt.Example/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 
@@ -79,6 +80,7 @@ class Program
     private static void RunMultiSelectSample()
     {
         var options = Prompt.MultiSelect("Which cities would you like to visit?", new[] { "Seattle", "London", "Tokyo", "New York", "Singapore", "Shanghai" }, pageSize: 3, defaultValues: new[] { "Tokyo" });
+
         Console.WriteLine($"You picked {string.Join(", ", options)}");
     }
 

--- a/Sharprompt.Tests/PaginatorTests.cs
+++ b/Sharprompt.Tests/PaginatorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 using Sharprompt.Internal;
 
@@ -8,10 +9,12 @@ namespace Sharprompt.Tests;
 
 public class PaginatorTests
 {
+    private readonly Func<int, string, bool> _containsTextInputFilter = (item, keyword) => item.ToString().Contains(keyword, StringComparison.OrdinalIgnoreCase);
+
     [Fact]
     public void Basic()
     {
-        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), _containsTextInputFilter);
 
         var currentItems1 = paginator.CurrentItems;
 
@@ -29,7 +32,7 @@ public class PaginatorTests
     [Fact]
     public void Filter_NotEmpty()
     {
-        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), _containsTextInputFilter);
 
         paginator.UpdateFilter("0");
 
@@ -42,7 +45,7 @@ public class PaginatorTests
     [Fact]
     public void Filter_Empty()
     {
-        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), _containsTextInputFilter);
 
         paginator.UpdateFilter("x");
 
@@ -54,7 +57,7 @@ public class PaginatorTests
     [Fact]
     public void SelectedItem()
     {
-        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), _containsTextInputFilter);
 
         paginator.NextPage();
         paginator.NextItem();
@@ -68,7 +71,7 @@ public class PaginatorTests
     [Fact]
     public void SelectedItem_NotSelected()
     {
-        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), _containsTextInputFilter);
 
         var selected = paginator.TryGetSelectedItem(out _);
 
@@ -78,7 +81,7 @@ public class PaginatorTests
     [Fact]
     public void SelectedItem_EmptyList()
     {
-        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), _containsTextInputFilter);
 
         paginator.UpdateFilter("x");
         paginator.NextItem();

--- a/Sharprompt/Forms/MultiSelectForm.cs
+++ b/Sharprompt/Forms/MultiSelectForm.cs
@@ -15,7 +15,7 @@ internal class MultiSelectForm<T> : FormBase<IEnumerable<T>> where T : notnull
         options.EnsureOptions();
 
         _options = options;
-        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Empty, options.TextSelector)
+        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Empty, options.TextSelector, options.TextInputFilter)
         {
             LoopingSelection = options.LoopingSelection
         };

--- a/Sharprompt/Forms/SelectForm.cs
+++ b/Sharprompt/Forms/SelectForm.cs
@@ -14,7 +14,7 @@ internal class SelectForm<T> : FormBase<T> where T : notnull
         options.EnsureOptions();
 
         _options = options;
-        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Create(options.DefaultValue), options.TextSelector)
+        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Create(options.DefaultValue), options.TextSelector, options.TextInputFilter)
         {
             LoopingSelection = options.LoopingSelection
         };

--- a/Sharprompt/Internal/Paginator.cs
+++ b/Sharprompt/Internal/Paginator.cs
@@ -8,17 +8,19 @@ namespace Sharprompt.Internal;
 
 internal class Paginator<T> : IEnumerable<T> where T : notnull
 {
-    public Paginator(IEnumerable<T> items, int pageSize, Optional<T> defaultValue, Func<T, string> textSelector)
+    public Paginator(IEnumerable<T> items, int pageSize, Optional<T> defaultValue, Func<T, string> textSelector, Func<T, string, bool> textInputFilter)
     {
         _items = items.ToArray();
         _pageSize = pageSize <= 0 ? _items.Length : Math.Min(pageSize, _items.Length);
         _textSelector = textSelector;
+        _filterFunc = textInputFilter;
 
         InitializeDefaults(defaultValue);
     }
 
     private readonly T[] _items;
     private readonly Func<T, string> _textSelector;
+    private readonly Func<T, string, bool> _filterFunc;
 
     private int _pageSize;
     private T[] _filteredItems = Array.Empty<T>();
@@ -144,8 +146,8 @@ internal class Paginator<T> : IEnumerable<T> where T : notnull
 
     private void UpdateFilteredItems()
     {
-        _filteredItems = _items.Where(x => _textSelector(x).IndexOf(FilterKeyword, StringComparison.OrdinalIgnoreCase) != -1)
-                               .ToArray();
+        _filteredItems = _items.Where(x => _filterFunc(x, FilterKeyword))
+            .ToArray();
 
         PageCount = (_filteredItems.Length - 1) / _pageSize + 1;
 

--- a/Sharprompt/MultiSelectOptions.cs
+++ b/Sharprompt/MultiSelectOptions.cs
@@ -32,6 +32,8 @@ public class MultiSelectOptions<T> where T : notnull
 
     public Func<T, string> TextSelector { get; set; } = x => x.ToString()!;
 
+    public Func<T, string, bool> TextInputFilter { get; set; } = (item, keyword) => item.ToString().Contains(keyword, StringComparison.OrdinalIgnoreCase);
+
     public Func<int, int, int, string> Pagination { get; set; } = (count, current, total) => string.Format(Resource.Message_Pagination, count, current, total);
 
     public bool LoopingSelection { get; set; } = true;

--- a/Sharprompt/Prompt.Basic.cs
+++ b/Sharprompt/Prompt.Basic.cs
@@ -106,7 +106,7 @@ public static partial class Prompt
         return Select(options);
     }
 
-    public static T Select<T>(string message, IEnumerable<T>? items = default, int pageSize = int.MaxValue, object? defaultValue = default, Func<T, string>? textSelector = default) where T : notnull
+    public static T Select<T>(string message, IEnumerable<T>? items = default, int pageSize = int.MaxValue, object? defaultValue = default, Func<T, string>? textSelector = default, Func<T, string, bool>? textInputFilter = default) where T : notnull
     {
         return Select<T>(options =>
         {
@@ -123,6 +123,11 @@ public static partial class Prompt
             if (textSelector is not null)
             {
                 options.TextSelector = textSelector;
+            }
+
+            if (textInputFilter is not null)
+            {
+                options.TextInputFilter = textInputFilter;
             }
         });
     }
@@ -143,7 +148,9 @@ public static partial class Prompt
         return MultiSelect(options);
     }
 
-    public static IEnumerable<T> MultiSelect<T>(string message, IEnumerable<T>? items = null, int pageSize = int.MaxValue, int minimum = 1, int maximum = int.MaxValue, IEnumerable<T>? defaultValues = default, Func<T, string>? textSelector = default) where T : notnull
+    public static IEnumerable<T> MultiSelect<T>(string message,
+        IEnumerable<T>? items = null, int pageSize = int.MaxValue, int minimum = 1, int maximum = int.MaxValue,
+        IEnumerable<T>? defaultValues = default, Func<T, string>? textSelector = default, Func<T, string, bool>? textInputFilter = default) where T : notnull
     {
         return MultiSelect<T>(options =>
         {
@@ -166,6 +173,11 @@ public static partial class Prompt
             if (textSelector is not null)
             {
                 options.TextSelector = textSelector;
+            }
+
+            if (textInputFilter is not null)
+            {
+                options.TextInputFilter = textInputFilter;
             }
         });
     }

--- a/Sharprompt/SelectOptions.cs
+++ b/Sharprompt/SelectOptions.cs
@@ -27,6 +27,8 @@ public class SelectOptions<T> where T : notnull
 
     public Func<T, string> TextSelector { get; set; } = x => x.ToString()!;
 
+    public Func<T, string, bool> TextInputFilter { get; set; } = (item, keyword) => item.ToString().Contains(keyword, StringComparison.OrdinalIgnoreCase);
+
     public Func<int, int, int, string> Pagination { get; set; } = (count, current, total) => string.Format(Resource.Message_Pagination, count, current, total);
 
     public bool LoopingSelection { get; set; } = true;


### PR DESCRIPTION
Adds a new constructor parameter that accepts a function for filtering text input (i.e. how text is filtered when typing into a Select or MultiSelect Prompt). This allows developers to override the default behavior (in this case `.Contains(keyword)`) with custom behavior such as fuzzy matching. This helps with long inputs, where you may have multiple keywords or matches in your string but are unsure about the order or exact input.

## Motivation

I wanted to use Sharprompt to develop an internal tool, where I wanted to prompt the user to select one or multiple work items from a DevOps board. Sometimes it helps to filter with a text input such as "deliv closed" to match the row "Title: Delivery Menu, Type: User Story, State: Closed" or similar. For my own use case I would like a fuzzy match akin to `fzf` but was unable to implement that because the behavior is hardcoded into the `paginator`.

The PR may not be perfect, so I created it as a draft. What are your thoughts on this?