### PR TITLE
Upgrade to .NET 8 and latest C#

### DIFF
--- a/Sharprompt.Example/Program.cs
+++ b/Sharprompt.Example/Program.cs
@@ -54,7 +54,7 @@ class Program
 
     private static void RunInputSample()
     {
-        var name = Prompt.Input<string>("What's your name?", defaultValue: "John Smith", placeholder: "At least 3 characters", validators: new[] { Validators.Required(), Validators.MinLength(3) });
+        var name = Prompt.Input<string>("What's your name?", defaultValue: "John Smith", placeholder: "At least 3 characters", validators: [Validators.Required(), Validators.MinLength(3)]);
         Console.WriteLine($"Hello, {name}!");
     }
 
@@ -66,19 +66,19 @@ class Program
 
     private static void RunPasswordSample()
     {
-        var secret = Prompt.Password("Type new password", placeholder: "At least 8 characters", validators: new[] { Validators.Required(), Validators.MinLength(8) });
+        var secret = Prompt.Password("Type new password", placeholder: "At least 8 characters", validators: [Validators.Required(), Validators.MinLength(8)]);
         Console.WriteLine($"Password OK, {secret}");
     }
 
     private static void RunSelectSample()
     {
-        var city = Prompt.Select("Select your city", new[] { "Seattle", "London", "Tokyo", "New York", "Singapore", "Shanghai" }, pageSize: 3);
+        var city = Prompt.Select("Select your city", ["Seattle", "London", "Tokyo", "New York", "Singapore", "Shanghai"], pageSize: 3);
         Console.WriteLine($"Hello, {city}!");
     }
 
     private static void RunMultiSelectSample()
     {
-        var options = Prompt.MultiSelect("Which cities would you like to visit?", new[] { "Seattle", "London", "Tokyo", "New York", "Singapore", "Shanghai" }, pageSize: 3, defaultValues: new[] { "Tokyo" });
+        var options = Prompt.MultiSelect("Which cities would you like to visit?", ["Seattle", "London", "Tokyo", "New York", "Singapore", "Shanghai"], pageSize: 3, defaultValues: ["Tokyo"]);
         Console.WriteLine($"You picked {string.Join(", ", options)}");
     }
 
@@ -90,7 +90,7 @@ class Program
 
     private static void RunMultiSelectEnumSample()
     {
-        var value = Prompt.MultiSelect<MyEnum>("Select enum value", defaultValues: new[] { MyEnum.Bar });
+        var value = Prompt.MultiSelect<MyEnum>("Select enum value", defaultValues: [MyEnum.Bar]);
         Console.WriteLine($"You picked {string.Join(", ", value)}");
     }
 

--- a/Sharprompt.Tests/PropertyMetadataTests.cs
+++ b/Sharprompt.Tests/PropertyMetadataTests.cs
@@ -297,9 +297,9 @@ public class PropertyMetadataTests
 
         public static IEnumerable<int> GetSelectItems()
         {
-            return new[] { 1, 2, 3, 4, 5 };
+            return [1, 2, 3, 4, 5];
         }
 
-        public static IEnumerable<int> SelectItems => new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        public static IEnumerable<int> SelectItems => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     }
 }

--- a/Sharprompt/BindIgnoreAttribute.cs
+++ b/Sharprompt/BindIgnoreAttribute.cs
@@ -3,6 +3,4 @@
 namespace Sharprompt;
 
 [AttributeUsage(AttributeTargets.Property)]
-public sealed class BindIgnoreAttribute : Attribute
-{
-}
+public sealed class BindIgnoreAttribute : Attribute;

--- a/Sharprompt/Forms/FormRenderer.cs
+++ b/Sharprompt/Forms/FormRenderer.cs
@@ -5,14 +5,9 @@ using Sharprompt.Internal;
 
 namespace Sharprompt.Forms;
 
-internal class FormRenderer : IDisposable
+internal class FormRenderer(IConsoleDriver consoleDriver) : IDisposable
 {
-    public FormRenderer(IConsoleDriver consoleDriver)
-    {
-        _offscreenBuffer = new OffscreenBuffer(consoleDriver);
-    }
-
-    private readonly OffscreenBuffer _offscreenBuffer;
+    private readonly OffscreenBuffer _offscreenBuffer = new(consoleDriver);
 
     public string? ErrorMessage { get; set; }
 

--- a/Sharprompt/Forms/ListForm.cs
+++ b/Sharprompt/Forms/ListForm.cs
@@ -21,7 +21,7 @@ internal class ListForm<T> : TextFormBase<IEnumerable<T>> where T : notnull
 
     private readonly ListOptions<T> _options;
 
-    private readonly List<T> _inputItems = new();
+    private readonly List<T> _inputItems = [];
 
     protected override void InputTemplate(OffscreenBuffer offscreenBuffer)
     {

--- a/Sharprompt/Forms/MultiSelectForm.cs
+++ b/Sharprompt/Forms/MultiSelectForm.cs
@@ -41,7 +41,7 @@ internal class MultiSelectForm<T> : FormBase<IEnumerable<T>> where T : notnull
     private readonly MultiSelectOptions<T> _options;
     private readonly Paginator<T> _paginator;
 
-    private readonly HashSet<T> _selectedItems = new();
+    private readonly HashSet<T> _selectedItems = [];
 
     protected override void InputTemplate(OffscreenBuffer offscreenBuffer)
     {

--- a/Sharprompt/Internal/EastAsianWidth.cs
+++ b/Sharprompt/Internal/EastAsianWidth.cs
@@ -61,7 +61,7 @@ internal static class EastAsianWidth
     }
 
     private static readonly EastAsianWidthRange[] s_eastAsianWidthRanges =
-    {
+    [
         new(161, 0, true),
         new(164, 0, true),
         new(167, 1, true),
@@ -362,7 +362,7 @@ internal static class EastAsianWidth
         new(917760, 239, true),
         new(983040, 65533, true),
         new(1048576, 65533, true)
-    };
+    ];
 
     public readonly record struct EastAsianWidthRange(uint Start, ushort Count, bool Ambiguous);
 }

--- a/Sharprompt/Internal/EnumHelper.cs
+++ b/Sharprompt/Internal/EnumHelper.cs
@@ -10,11 +10,7 @@ internal static class EnumHelper<TEnum> where TEnum : notnull
 {
     static EnumHelper()
     {
-#if NET7_0_OR_GREATER
         var values = (TEnum[])Enum.GetValuesAsUnderlyingType(typeof(TEnum));
-#else
-        var values = (TEnum[])Enum.GetValues(typeof(TEnum));
-#endif
 
         foreach (var value in values)
         {

--- a/Sharprompt/Internal/NullItemsProvider.cs
+++ b/Sharprompt/Internal/NullItemsProvider.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Sharprompt.Internal;
 
 internal class NullItemsProvider : IItemsProvider
 {
-    public IEnumerable<T> GetItems<T>(PropertyInfo targetPropertyInfo) where T : notnull => Enumerable.Empty<T>();
+    public IEnumerable<T> GetItems<T>(PropertyInfo targetPropertyInfo) where T : notnull => [];
 
     public static IItemsProvider Instance { get; } = new NullItemsProvider();
 }

--- a/Sharprompt/Internal/OffscreenBuffer.cs
+++ b/Sharprompt/Internal/OffscreenBuffer.cs
@@ -16,7 +16,7 @@ internal class OffscreenBuffer : IDisposable
     }
 
     private readonly IConsoleDriver _consoleDriver;
-    private readonly List<List<TextInfo>> _outputBuffer = new() { new List<TextInfo>() };
+    private readonly List<List<TextInfo>> _outputBuffer = [new()];
 
     private int _cursorBottom;
     private Cursor? _pushedCursor;
@@ -37,7 +37,7 @@ internal class OffscreenBuffer : IDisposable
         _outputBuffer.Last().Add(new TextInfo(text, color));
     }
 
-    public void WriteLine() => _outputBuffer.Add(new List<TextInfo>());
+    public void WriteLine() => _outputBuffer.Add([]);
 
     public void PushCursor()
     {
@@ -105,7 +105,7 @@ internal class OffscreenBuffer : IDisposable
     public void ClearBuffer()
     {
         _outputBuffer.Clear();
-        _outputBuffer.Add(new List<TextInfo>());
+        _outputBuffer.Add([]);
 
         _pushedCursor = null;
     }

--- a/Sharprompt/Internal/Optional.cs
+++ b/Sharprompt/Internal/Optional.cs
@@ -1,10 +1,16 @@
 ﻿namespace Sharprompt.Internal;
 
-internal readonly struct Optional<T>(T value)
+internal readonly struct Optional<T>
 {
-    public bool HasValue => true;
+    public Optional(T value)
+    {
+        HasValue = true;
+        Value = value;
+    }
 
-    public T Value { get; } = value;
+    public bool HasValue { get; } = false;
+
+    public T Value { get; } = default!;
 
     public static readonly Optional<T> Empty = new();
 

--- a/Sharprompt/Internal/Optional.cs
+++ b/Sharprompt/Internal/Optional.cs
@@ -1,16 +1,10 @@
 ﻿namespace Sharprompt.Internal;
 
-internal readonly struct Optional<T>
+internal readonly struct Optional<T>(T value)
 {
-    public Optional(T value)
-    {
-        HasValue = true;
-        Value = value;
-    }
+    public bool HasValue => true;
 
-    public bool HasValue { get; }
-
-    public T Value { get; }
+    public T Value { get; } = value;
 
     public static readonly Optional<T> Empty = new();
 

--- a/Sharprompt/Internal/Paginator.cs
+++ b/Sharprompt/Internal/Paginator.cs
@@ -21,7 +21,7 @@ internal class Paginator<T> : IEnumerable<T> where T : notnull
     private readonly Func<T, string> _textSelector;
 
     private int _pageSize;
-    private T[] _filteredItems = Array.Empty<T>();
+    private T[] _filteredItems = [];
     private int _selectedIndex = -1;
 
     public ReadOnlySpan<T> CurrentItems => new(_filteredItems, _pageSize * CurrentPage, Count);

--- a/Sharprompt/Internal/ValidatorsExtensions.cs
+++ b/Sharprompt/Internal/ValidatorsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 
 namespace Sharprompt.Internal;
 
@@ -9,7 +8,7 @@ internal static class ValidatorsExtensions
 {
     public static void Merge(this IList<Func<object?, ValidationResult?>> source, IEnumerable<Func<object?, ValidationResult?>>? validators)
     {
-        foreach (var validator in validators ?? Enumerable.Empty<Func<object?, ValidationResult?>>())
+        foreach (var validator in validators ?? [])
         {
             source.Add(validator);
         }

--- a/Sharprompt/ListOptions.cs
+++ b/Sharprompt/ListOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 
 using Sharprompt.Strings;
 
@@ -11,7 +10,7 @@ public class ListOptions<T> where T : notnull
 {
     public string Message { get; set; } = null!;
 
-    public IEnumerable<T> DefaultValues { get; set; } = Enumerable.Empty<T>();
+    public IEnumerable<T> DefaultValues { get; set; } = [];
 
     public int Minimum { get; set; } = 1;
 

--- a/Sharprompt/MultiSelectOptions.cs
+++ b/Sharprompt/MultiSelectOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Sharprompt.Internal;
 using Sharprompt.Strings;
@@ -22,7 +21,7 @@ public class MultiSelectOptions<T> where T : notnull
 
     public IEnumerable<T> Items { get; set; } = null!;
 
-    public IEnumerable<T> DefaultValues { get; set; } = Enumerable.Empty<T>();
+    public IEnumerable<T> DefaultValues { get; set; } = [];
 
     public int PageSize { get; set; } = int.MaxValue;
 

--- a/Sharprompt/Prompt.Bind.cs
+++ b/Sharprompt/Prompt.Bind.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 using Sharprompt.Forms;
@@ -77,7 +76,7 @@ public static partial class Prompt
         return List<T>(options =>
         {
             options.Message = propertyMetadata.Message;
-            options.DefaultValues = (IEnumerable<T>?)propertyMetadata.DefaultValue ?? Enumerable.Empty<T>();
+            options.DefaultValues = (IEnumerable<T>?)propertyMetadata.DefaultValue ?? [];
 
             options.Validators.Merge(propertyMetadata.Validators);
         });
@@ -91,7 +90,7 @@ public static partial class Prompt
         {
             options.Message = propertyMetadata.Message;
             options.Items = propertyMetadata.ItemsProvider.GetItems<T>(propertyMetadata.PropertyInfo);
-            options.DefaultValues = (IEnumerable<T>?)propertyMetadata.DefaultValue ?? Enumerable.Empty<T>();
+            options.DefaultValues = (IEnumerable<T>?)propertyMetadata.DefaultValue ?? [];
         });
     }
 
@@ -123,6 +122,6 @@ public static partial class Prompt
         var method = typeof(Prompt).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static)!
                                    .MakeGenericMethod(genericType ?? propertyMetadata.Type);
 
-        return method.Invoke(null, new object[] { propertyMetadata })!;
+        return method.Invoke(null, [propertyMetadata])!;
     }
 }

--- a/Sharprompt/Sharprompt.csproj
+++ b/Sharprompt/Sharprompt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Sharprompt/Symbol.cs
+++ b/Sharprompt/Symbol.cs
@@ -3,18 +3,9 @@ using System.Runtime.InteropServices;
 
 namespace Sharprompt;
 
-public class Symbol
+public class Symbol(string value, string fallbackValue)
 {
-    public Symbol(string value, string fallbackValue)
-    {
-        _value = value;
-        _fallbackValue = fallbackValue;
-    }
-
-    private readonly string _value;
-    private readonly string _fallbackValue;
-
-    public override string ToString() => IsUnicodeSupported ? _value : _fallbackValue;
+    public override string ToString() => IsUnicodeSupported ? value : fallbackValue;
 
     public static implicit operator string(Symbol symbol) => symbol.ToString();
 


### PR DESCRIPTION
This pull request includes several changes aimed at simplifying the codebase and improving consistency by replacing `new[] { ... }` with `[...]` and refactoring class constructors. The most important changes include modifications to various sample methods, class constructors, and internal structures.

### Simplification and consistency improvements:

* [`Sharprompt.Example/Program.cs`](diffhunk://#diff-2e9d789e319dd69c2a27dec8e16acfa4bf36bf18cbbf7d57d0ab58499d46de6eL57-R57): Replaced `new[] { ... }` with `[...]` in multiple sample methods, such as `RunInputSample`, `RunPasswordSample`, `RunSelectSample`, `RunMultiSelectSample`, and `RunSelectEnumSample`. [[1]](diffhunk://#diff-2e9d789e319dd69c2a27dec8e16acfa4bf36bf18cbbf7d57d0ab58499d46de6eL57-R57) [[2]](diffhunk://#diff-2e9d789e319dd69c2a27dec8e16acfa4bf36bf18cbbf7d57d0ab58499d46de6eL69-R81) [[3]](diffhunk://#diff-2e9d789e319dd69c2a27dec8e16acfa4bf36bf18cbbf7d57d0ab58499d46de6eL93-R93)
* [`Sharprompt.Tests/PropertyMetadataTests.cs`](diffhunk://#diff-eeb58b83fbb1b649ec8d152259fdefcc6f03d1254f06755bd17f1f6ab47af9a0L300-R303): Changed `new[] { ... }` to `[...]` in `GetSelectItems` and `SelectItems` properties.

### Class constructor refactoring:

* [`Sharprompt/Forms/FormRenderer.cs`](diffhunk://#diff-1604b47332349a3e4c756e759b994869d42857288a53682826b4e9b719d0bc20L8-R10): Modified the class constructor to use inline initialization for `_offscreenBuffer`.
* [`Sharprompt/Internal/Optional.cs`](diffhunk://#diff-63e7f77329c4c913dee7176d0164bac075cb93415c69ac81e67ceaf09258e8e0L3-R7): Refactored `Optional<T>` to use a primary constructor and simplified property initialization.
* [`Sharprompt/Symbol.cs`](diffhunk://#diff-e227dadcd139f1c519ececf136ecfa3622ef54c507ec2dbcd2cc04a0013629f6L6-R8): Updated `Symbol` class to use primary constructor and removed redundant fields.

### Internal structure updates:

* [`Sharprompt/Internal/OffscreenBuffer.cs`](diffhunk://#diff-00ab0b246b15013755fbdd19159795714ea3f6f24fe954aead89fcdb3e24f3d9L19-R19): Replaced `new List<TextInfo>()` with `[]` in `_outputBuffer` initialization and related methods. [[1]](diffhunk://#diff-00ab0b246b15013755fbdd19159795714ea3f6f24fe954aead89fcdb3e24f3d9L19-R19) [[2]](diffhunk://#diff-00ab0b246b15013755fbdd19159795714ea3f6f24fe954aead89fcdb3e24f3d9L40-R40) [[3]](diffhunk://#diff-00ab0b246b15013755fbdd19159795714ea3f6f24fe954aead89fcdb3e24f3d9L108-R108)
* [`Sharprompt/Internal/Paginator.cs`](diffhunk://#diff-08cd0c2f1b39d4f722cc8979a4807a9def2550c4013a850356a02fdeb4ed58baL24-R24): Changed `_filteredItems` initialization from `Array.Empty<T>()` to `[]`.

### Project configuration update:

* [`Sharprompt/Sharprompt.csproj`](diffhunk://#diff-d5be16070ea17acdc0654f47e43252a73e8406a744abd377200352fcd17c7426L4-R4): Updated the project to target only .NET 8.0 instead of multiple frameworks.