### PR TITLE
Added: possibility to turn off TextSelector in Select and MultiSelect; possibility to select empty value when default value is provided in InputForm.

### DIFF
--- a/Sharprompt.Example/ExampleType.cs
+++ b/Sharprompt.Example/ExampleType.cs
@@ -3,6 +3,7 @@
 public enum ExampleType
 {
     Input,
+    InputWithDefaultValueSelection,
     Confirm,
     Password,
     Select,

--- a/Sharprompt.Example/Models/MyFormModel.cs
+++ b/Sharprompt.Example/Models/MyFormModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Sharprompt.Example.Models;
@@ -15,19 +16,23 @@ public class MyFormModel
     [Required]
     public string Name { get; set; } = null!;
 
-    [Display(Name = "Type new password", Order = 2)]
+    [Display(Name = "What's your favourite colour?", Order = 2)]
+    [DefaultValueMustBeSelected]
+    public string FavouriteColour { get; set; } = "blue";
+
+    [Display(Name = "Type new password", Order = 3)]
     [DataType(DataType.Password)]
     [Required]
     [MinLength(8)]
     public string Password { get; set; } = null!;
 
-    [Display(Name = "Select enum value", Order = 3)]
+    [Display(Name = "Select enum value", Order = 4)]
     public MyEnum? MyEnum { get; set; }
 
-    [Display(Name = "Select enum values", Order = 4)]
+    [Display(Name = "Select enum values", Order = 5)]
     public IEnumerable<MyEnum> MyEnums { get; set; } = null!;
 
-    [Display(Name = "Please add item(s)", Order = 5)]
+    [Display(Name = "Please add item(s)", Order = 6)]
     public IEnumerable<string> Lists { get; set; } = null!;
 
     [Display(Name = "Are you ready?", Order = 10)]

--- a/Sharprompt.Example/Models/MyFormModel.cs
+++ b/Sharprompt.Example/Models/MyFormModel.cs
@@ -32,7 +32,11 @@ public class MyFormModel
     [Display(Name = "Select enum values", Order = 5)]
     public IEnumerable<MyEnum> MyEnums { get; set; } = null!;
 
-    [Display(Name = "Please add item(s)", Order = 6)]
+    [Display(Name = "Select enum values without text selector", Order = 6)]
+    [DoNotUseTextSelector]
+    public IEnumerable<MyEnum> MyEnumsWithoutTextSelector { get; set; } = null!;
+
+    [Display(Name = "Please add item(s)", Order = 7)]
     public IEnumerable<string> Lists { get; set; } = null!;
 
     [Display(Name = "Are you ready?", Order = 10)]

--- a/Sharprompt.Example/Program.cs
+++ b/Sharprompt.Example/Program.cs
@@ -22,6 +22,9 @@ class Program
                 case ExampleType.Input:
                     RunInputSample();
                     break;
+                case ExampleType.InputWithDefaultValueSelection:
+                    RunInputSampleWithDefaultValueSelection();
+                    break;
                 case ExampleType.Confirm:
                     RunConfirmSample();
                     break;
@@ -56,6 +59,12 @@ class Program
     {
         var name = Prompt.Input<string>("What's your name?", defaultValue: "John Smith", placeholder: "At least 3 characters", validators: [Validators.Required(), Validators.MinLength(3)]);
         Console.WriteLine($"Hello, {name}!");
+    }
+
+    private static void RunInputSampleWithDefaultValueSelection()
+    {
+        var colour = Prompt.Input<string>("What's your favourite colour?", defaultValue: "blue", defaultValueMustBeSelected: true);
+        Console.WriteLine($"Your answer is: {colour}!");
     }
 
     private static void RunConfirmSample()

--- a/Sharprompt.Tests/PaginatorTests.cs
+++ b/Sharprompt.Tests/PaginatorTests.cs
@@ -52,6 +52,32 @@ public class PaginatorTests
     }
 
     [Fact]
+    public void Filter_NotEmpty_UseTextSelectorFalse()
+    {
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), false);
+
+        paginator.UpdateFilter("0");
+
+        var currentItems = paginator.CurrentItems;
+
+        Assert.Equal(5, currentItems.Length);
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, currentItems.ToArray());
+    }
+
+    [Fact]
+    public void Filter_Empty_UseTextSelectorFalse()
+    {
+        var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString(), false);
+
+        paginator.UpdateFilter("x");
+
+        var currentItems = paginator.CurrentItems;
+
+        Assert.Equal(5, currentItems.Length);
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, currentItems.ToArray());
+    }
+
+    [Fact]
     public void SelectedItem()
     {
         var paginator = new Paginator<int>(Enumerable.Range(0, 20), 5, Optional<int>.Empty, x => x.ToString());

--- a/Sharprompt.Tests/PropertyMetadataTests.cs
+++ b/Sharprompt.Tests/PropertyMetadataTests.cs
@@ -209,6 +209,19 @@ public class PropertyMetadataTests
         Assert.Equal(Enumerable.Range(1, 10), metadata[1].ItemsProvider.GetItems<int>(metadata[1].PropertyInfo));
     }
 
+    [Fact]
+    public void DefaultValueMustBeSelected()
+    {
+        var metadata = PropertyMetadataFactory.Create(new DefaultValueMustBeSelectedModel());
+
+        Assert.NotNull(metadata);
+        Assert.Equal(2, metadata.Count);
+
+        Assert.True(metadata[0].DefaultValueMustBeSelected);
+        Assert.False(metadata[1].DefaultValueMustBeSelected);
+    }
+
+
     public class BasicModel
     {
         [Display(Name = "Input Value", Prompt = "Required Value")]
@@ -301,5 +314,13 @@ public class PropertyMetadataTests
         }
 
         public static IEnumerable<int> SelectItems => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    }
+
+    public class DefaultValueMustBeSelectedModel
+    {
+        [DefaultValueMustBeSelected]
+        public string MemberValue1 { get; set; } = "something";
+
+        public string MemberValue2 { get; set; } = "nothing";
     }
 }

--- a/Sharprompt.Tests/PropertyMetadataTests.cs
+++ b/Sharprompt.Tests/PropertyMetadataTests.cs
@@ -221,6 +221,18 @@ public class PropertyMetadataTests
         Assert.False(metadata[1].DefaultValueMustBeSelected);
     }
 
+    [Fact]
+    public void DoNotUseTextSelector()
+    {
+        var metadata = PropertyMetadataFactory.Create(new DoNotUseTextSelectorModel());
+
+        Assert.NotNull(metadata);
+        Assert.Equal(2, metadata.Count);
+
+        Assert.True(metadata[0].UseTextSelector);
+        Assert.False(metadata[1].UseTextSelector);
+    }
+
 
     public class BasicModel
     {
@@ -322,5 +334,13 @@ public class PropertyMetadataTests
         public string MemberValue1 { get; set; } = "something";
 
         public string MemberValue2 { get; set; } = "nothing";
+    }
+
+    public class DoNotUseTextSelectorModel
+    {
+        public IEnumerable<string> StrArray { get; set; } = null!;
+
+        [DoNotUseTextSelector]
+        public IReadOnlyList<int> IntArray { get; set; } = null!;
     }
 }

--- a/Sharprompt/DefaultValueMustBeSelectedAttribute.cs
+++ b/Sharprompt/DefaultValueMustBeSelectedAttribute.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace Sharprompt;
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class DefaultValueMustBeSelectedAttribute : Attribute;

--- a/Sharprompt/DoNotUseTextSelectorAttribute.cs
+++ b/Sharprompt/DoNotUseTextSelectorAttribute.cs
@@ -1,0 +1,5 @@
+﻿using System;
+
+namespace Sharprompt;
+
+public class DoNotUseTextSelectorAttribute : Attribute;

--- a/Sharprompt/Fluent/MultiSelectOptionsExtensions.cs
+++ b/Sharprompt/Fluent/MultiSelectOptionsExtensions.cs
@@ -54,6 +54,13 @@ public static class MultiSelectOptionsExtensions
         return options;
     }
 
+    public static MultiSelectOptions<T> WithoutTextSelector<T>(this MultiSelectOptions<T> options) where T : notnull
+    {
+        options.UseTextSelector = false;
+
+        return options;
+    }
+
     public static MultiSelectOptions<T> WithPagination<T>(this MultiSelectOptions<T> options, Func<int, int, int, string> pagination) where T : notnull
     {
         options.Pagination = pagination;

--- a/Sharprompt/Fluent/SelectOptionsExtensions.cs
+++ b/Sharprompt/Fluent/SelectOptionsExtensions.cs
@@ -40,6 +40,13 @@ public static class SelectOptionsExtensions
         return options;
     }
 
+    public static SelectOptions<T> WithoutTextSelector<T>(this SelectOptions<T> options) where T : notnull
+    {
+        options.UseTextSelector = false;
+
+        return options;
+    }
+
     public static SelectOptions<T> WithPagination<T>(this SelectOptions<T> options, Func<int, int, int, string> pagination) where T : notnull
     {
         options.Pagination = pagination;

--- a/Sharprompt/Forms/InputForm.cs
+++ b/Sharprompt/Forms/InputForm.cs
@@ -10,6 +10,8 @@ internal class InputForm<T> : TextFormBase<T>
 {
     public InputForm(InputOptions<T> options)
     {
+        KeyHandlerMaps.Add(ConsoleKey.Tab, HandleTab);
+
         options.EnsureOptions();
 
         _options = options;
@@ -26,7 +28,14 @@ internal class InputForm<T> : TextFormBase<T>
 
         if (_defaultValue.HasValue)
         {
-            offscreenBuffer.WriteHint($"({_defaultValue.Value}) ");
+            if (_options.DefaultValueMustBeSelected)
+            {
+                offscreenBuffer.WriteHint($"({_defaultValue.Value} - Tab to select) ");
+            }
+            else
+            {
+                offscreenBuffer.WriteHint($"({_defaultValue.Value}) ");
+            }
         }
 
         if (InputBuffer.Length == 0 && !string.IsNullOrEmpty(_options.Placeholder))
@@ -65,7 +74,7 @@ internal class InputForm<T> : TextFormBase<T>
                     return false;
                 }
 
-                result = _defaultValue;
+                result = _options.DefaultValueMustBeSelected ? default : _defaultValue;
             }
             else
             {
@@ -82,5 +91,19 @@ internal class InputForm<T> : TextFormBase<T>
         result = default;
 
         return false;
+    }
+
+    protected bool HandleTab(ConsoleKeyInfo keyInfo)
+    {
+        if (_options.DefaultValueMustBeSelected && _defaultValue.HasValue)
+        {
+            InputBuffer.Clear();
+            foreach (var c in _defaultValue.Value.ToString())
+            {
+                InputBuffer.Insert(c);
+            }
+        }
+
+        return true;
     }
 }

--- a/Sharprompt/Forms/MultiSelectForm.cs
+++ b/Sharprompt/Forms/MultiSelectForm.cs
@@ -15,7 +15,7 @@ internal class MultiSelectForm<T> : FormBase<IEnumerable<T>> where T : notnull
         options.EnsureOptions();
 
         _options = options;
-        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Empty, options.TextSelector)
+        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Empty, options.TextSelector, options.UseTextSelector)
         {
             LoopingSelection = options.LoopingSelection
         };

--- a/Sharprompt/Forms/SelectForm.cs
+++ b/Sharprompt/Forms/SelectForm.cs
@@ -14,7 +14,7 @@ internal class SelectForm<T> : FormBase<T> where T : notnull
         options.EnsureOptions();
 
         _options = options;
-        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Create(options.DefaultValue), options.TextSelector)
+        _paginator = new Paginator<T>(options.Items, Math.Min(options.PageSize, Height - 2), Optional<T>.Create(options.DefaultValue), options.TextSelector, options.UseTextSelector)
         {
             LoopingSelection = options.LoopingSelection
         };

--- a/Sharprompt/InputOptions.cs
+++ b/Sharprompt/InputOptions.cs
@@ -12,6 +12,8 @@ public class InputOptions<T>
 
     public object? DefaultValue { get; set; }
 
+    public bool DefaultValueMustBeSelected { get; set; } = false;
+
     public IList<Func<object?, ValidationResult?>> Validators { get; } = new List<Func<object?, ValidationResult?>>();
 
     internal void EnsureOptions()

--- a/Sharprompt/Internal/Paginator.cs
+++ b/Sharprompt/Internal/Paginator.cs
@@ -8,17 +8,19 @@ namespace Sharprompt.Internal;
 
 internal class Paginator<T> : IEnumerable<T> where T : notnull
 {
-    public Paginator(IEnumerable<T> items, int pageSize, Optional<T> defaultValue, Func<T, string> textSelector)
+    public Paginator(IEnumerable<T> items, int pageSize, Optional<T> defaultValue, Func<T, string> textSelector, bool useTextSelector = true)
     {
         _items = items.ToArray();
         _pageSize = pageSize <= 0 ? _items.Length : Math.Min(pageSize, _items.Length);
         _textSelector = textSelector;
+        _useTextSelector = useTextSelector;
 
         InitializeDefaults(defaultValue);
     }
 
     private readonly T[] _items;
     private readonly Func<T, string> _textSelector;
+    private readonly bool _useTextSelector;
 
     private int _pageSize;
     private T[] _filteredItems = [];
@@ -117,6 +119,11 @@ internal class Paginator<T> : IEnumerable<T> where T : notnull
 
     public void UpdateFilter(string keyword)
     {
+        if (!_useTextSelector)
+        {
+            return;
+        }
+
         FilterKeyword = keyword;
 
         _selectedIndex = -1;

--- a/Sharprompt/Internal/PropertyMetadata.cs
+++ b/Sharprompt/Internal/PropertyMetadata.cs
@@ -33,6 +33,7 @@ internal class PropertyMetadata
             .Select(x => new ValidationAttributeAdapter(x).GetValidator(propertyInfo.Name, model))
             .ToArray();
         ItemsProvider = GetItemsProvider(propertyInfo);
+        UseTextSelector = propertyInfo.GetCustomAttribute<DoNotUseTextSelectorAttribute>() is null;
     }
 
     public PropertyInfo PropertyInfo { get; }
@@ -48,6 +49,7 @@ internal class PropertyMetadata
     public bool DefaultValueMustBeSelected { get; }
     public IReadOnlyList<Func<object?, ValidationResult?>> Validators { get; }
     public IItemsProvider ItemsProvider { get; }
+    public bool UseTextSelector { get; set; }
 
     public FormType DetermineFormType()
     {

--- a/Sharprompt/MultiSelectOptions.cs
+++ b/Sharprompt/MultiSelectOptions.cs
@@ -31,6 +31,8 @@ public class MultiSelectOptions<T> where T : notnull
 
     public Func<T, string> TextSelector { get; set; } = x => x.ToString()!;
 
+    public bool UseTextSelector { get; set; } = true;
+
     public Func<int, int, int, string> Pagination { get; set; } = (count, current, total) => string.Format(Resource.Message_Pagination, count, current, total);
 
     public bool LoopingSelection { get; set; } = true;

--- a/Sharprompt/Prompt.Basic.cs
+++ b/Sharprompt/Prompt.Basic.cs
@@ -107,7 +107,7 @@ public static partial class Prompt
         return Select(options);
     }
 
-    public static T Select<T>(string message, IEnumerable<T>? items = default, int pageSize = int.MaxValue, object? defaultValue = default, Func<T, string>? textSelector = default) where T : notnull
+    public static T Select<T>(string message, IEnumerable<T>? items = default, int pageSize = int.MaxValue, object? defaultValue = default, Func<T, string>? textSelector = default, bool useTextSelector = true) where T : notnull
     {
         return Select<T>(options =>
         {
@@ -125,6 +125,8 @@ public static partial class Prompt
             {
                 options.TextSelector = textSelector;
             }
+
+            options.UseTextSelector = useTextSelector;
         });
     }
 
@@ -144,7 +146,7 @@ public static partial class Prompt
         return MultiSelect(options);
     }
 
-    public static IEnumerable<T> MultiSelect<T>(string message, IEnumerable<T>? items = null, int pageSize = int.MaxValue, int minimum = 1, int maximum = int.MaxValue, IEnumerable<T>? defaultValues = default, Func<T, string>? textSelector = default) where T : notnull
+    public static IEnumerable<T> MultiSelect<T>(string message, IEnumerable<T>? items = null, int pageSize = int.MaxValue, int minimum = 1, int maximum = int.MaxValue, IEnumerable<T>? defaultValues = default, Func<T, string>? textSelector = default, bool useTextSelector = true) where T : notnull
     {
         return MultiSelect<T>(options =>
         {
@@ -168,6 +170,8 @@ public static partial class Prompt
             {
                 options.TextSelector = textSelector;
             }
+
+            options.UseTextSelector = useTextSelector;
         });
     }
 

--- a/Sharprompt/Prompt.Basic.cs
+++ b/Sharprompt/Prompt.Basic.cs
@@ -25,13 +25,14 @@ public static partial class Prompt
         return Input(options);
     }
 
-    public static T Input<T>(string message, object? defaultValue = default, string? placeholder = default, IList<Func<object?, ValidationResult?>>? validators = default)
+    public static T Input<T>(string message, object? defaultValue = default, bool defaultValueMustBeSelected = false, string? placeholder = default, IList<Func<object?, ValidationResult?>>? validators = default)
     {
         return Input<T>(options =>
         {
             options.Message = message;
             options.Placeholder = placeholder;
             options.DefaultValue = defaultValue;
+            options.DefaultValueMustBeSelected = defaultValueMustBeSelected;
 
             options.Validators.Merge(validators);
         });

--- a/Sharprompt/Prompt.Bind.cs
+++ b/Sharprompt/Prompt.Bind.cs
@@ -92,6 +92,7 @@ public static partial class Prompt
             options.Message = propertyMetadata.Message;
             options.Items = propertyMetadata.ItemsProvider.GetItems<T>(propertyMetadata.PropertyInfo);
             options.DefaultValues = (IEnumerable<T>?)propertyMetadata.DefaultValue ?? [];
+            options.UseTextSelector = propertyMetadata.UseTextSelector;
         });
     }
 
@@ -115,6 +116,7 @@ public static partial class Prompt
             options.Message = propertyMetadata.Message;
             options.Items = propertyMetadata.ItemsProvider.GetItems<T>(propertyMetadata.PropertyInfo);
             options.DefaultValue = propertyMetadata.DefaultValue;
+            options.UseTextSelector = propertyMetadata.UseTextSelector;
         });
     }
 

--- a/Sharprompt/Prompt.Bind.cs
+++ b/Sharprompt/Prompt.Bind.cs
@@ -63,6 +63,7 @@ public static partial class Prompt
         {
             options.Message = propertyMetadata.Message;
             options.DefaultValue = propertyMetadata.DefaultValue;
+            options.DefaultValueMustBeSelected = propertyMetadata.DefaultValueMustBeSelected;
             options.Placeholder = propertyMetadata.Placeholder;
 
             options.Validators.Merge(propertyMetadata.Validators);

--- a/Sharprompt/SelectOptions.cs
+++ b/Sharprompt/SelectOptions.cs
@@ -27,6 +27,8 @@ public class SelectOptions<T> where T : notnull
 
     public Func<T, string> TextSelector { get; set; } = x => x.ToString()!;
 
+    public bool UseTextSelector { get; set; } = true;
+
     public Func<int, int, int, string> Pagination { get; set; } = (count, current, total) => string.Format(Resource.Message_Pagination, count, current, total);
 
     public bool LoopingSelection { get; set; } = true;


### PR DESCRIPTION
Hello,

I wanted to turn text selector off in multiselect input. I didn't find the option to do it, so I created this pull request.
I also found this issue: [https://github.com/shibayan/Sharprompt/issues/297](url), so I covered it as well (hopefully).
To sum up:
1. Added possibility to turn off text selector in SelectInput and MultiSelectInput.
2. Added possibility to select empty value in InputForm when default value is provided. If this mode is on Enter select empty value (or value which is typed/inserted) and Tab insert default value. If not, the behaviour is the same as now - Enter select default value.

I recoreded short demo:

https://github.com/user-attachments/assets/77cf2f86-51c6-434d-b689-bfa40048c3ba

Please take a look and think if you want to include this PR in your library. Feel free to leave me comments about code quality, style etc.
