### PR TITLE
Enhance project metadata for clarity and detail

### DIFF
--- a/src/Sharprompt/Sharprompt.csproj
+++ b/src/Sharprompt/Sharprompt.csproj
@@ -7,14 +7,15 @@
   <PropertyGroup>
     <Authors>shibayan</Authors>
     <Copyright>Copyright (c) Tatsuro Shibamura 2019</Copyright>
-    <Description>Interactive command-line based application framework for C#</Description>
+    <Description>Build interactive command-line prompts for C# applications with input, selection, validation, and model binding.</Description>
     <PackageId>Sharprompt</PackageId>
+    <PackageTitle>Sharprompt</PackageTitle>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/shibayan/Sharprompt</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/shibayan/Sharprompt/releases/tag/v$(Version)</PackageReleaseNotes>
+    <PackageProjectUrl>https://shibayan.github.io/Sharprompt/</PackageProjectUrl>
+    <PackageReleaseNotes>Release notes: https://github.com/shibayan/Sharprompt/releases/tag/v$(Version)</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageTags>cli;command-line;console;interactive;prompt;terminal</PackageTags>
+    <PackageTags>cli;command-line;console;csharp;dotnet;interactive;model-binding;prompt;terminal;validation</PackageTags>
     <RepositoryUrl>https://github.com/shibayan/Sharprompt</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the NuGet package metadata in the `Sharprompt.csproj` file to improve discoverability and provide more accurate information about the package. The changes clarify the package's description, update links, and enhance search tags.

NuGet package metadata improvements:

* Updated the `Description` to better explain the features of the package, emphasizing input, selection, validation, and model binding.
* Added a `PackageTitle` property for clearer identification.
* Changed the `PackageProjectUrl` to point to the documentation site instead of the GitHub repository.
* Updated the `PackageReleaseNotes` to include a prefix and link to the release notes.
* Expanded `PackageTags` to include additional relevant keywords such as `csharp`, `dotnet`, `model-binding`, and `validation` for better searchability.