### PR TITLE
Fall back to reflection for enum types not registered by the source generator

### DIFF
--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -40,7 +40,10 @@ public static class EnumMetadataRegistry
 
     internal static EnumMetadata<TEnum> CreateFallbackMetadata<TEnum>() where TEnum : notnull
     {
+        // GetFields does not guarantee ordering, so sort by MetadataToken to get
+        // the declaration order, matching the source generator semantics.
         var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
+                                   .OrderBy(field => field.MetadataToken)
                                    .Select((field, index) => (value: (TEnum)field.GetValue(null)!, index, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
                                    .ToArray();
 

--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -1,6 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
 
 namespace Sharprompt;
 
@@ -15,18 +18,51 @@ public static class EnumMetadataRegistry
 
     internal static bool TryGet<TEnum>(out IReadOnlyList<TEnum> values, out Func<TEnum, string> textSelector) where TEnum : notnull
     {
-        if (s_metadata.TryGetValue(typeof(TEnum), out var metadata))
+        if (!s_metadata.TryGetValue(typeof(TEnum), out var metadata))
         {
-            var item = (EnumMetadata<TEnum>)metadata;
-            values = item.Values;
-            textSelector = item.TextSelector;
-            return true;
+            if (!typeof(TEnum).IsEnum)
+            {
+                values = null!;
+                textSelector = null!;
+                return false;
+            }
+
+            metadata = s_metadata.GetOrAdd(typeof(TEnum), static _ => CreateFallbackMetadata<TEnum>());
         }
 
-        values = null!;
-        textSelector = null!;
-        return false;
+        var item = (EnumMetadata<TEnum>)metadata;
+
+        values = item.Values;
+        textSelector = item.TextSelector;
+
+        return true;
     }
 
-    private sealed record EnumMetadata<TEnum>(IReadOnlyList<TEnum> Values, Func<TEnum, string> TextSelector);
+    internal static EnumMetadata<TEnum> CreateFallbackMetadata<TEnum>() where TEnum : notnull
+    {
+        var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
+                                   .Select((field, index) => (value: (TEnum)field.GetValue(null)!, index, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
+                                   .ToArray();
+
+        var values = members.OrderBy(x => x.displayAttribute?.GetOrder() ?? int.MaxValue)
+                            .ThenBy(x => x.index)
+                            .Select(x => x.value)
+                            .ToArray();
+
+        var displayNames = new Dictionary<TEnum, string>();
+
+        foreach (var member in members)
+        {
+            var displayName = member.displayAttribute?.GetName();
+
+            if (displayName is not null)
+            {
+                displayNames.TryAdd(member.value, displayName);
+            }
+        }
+
+        return new EnumMetadata<TEnum>(values, value => displayNames.TryGetValue(value, out var displayName) ? displayName : value.ToString()!);
+    }
+
+    internal sealed record EnumMetadata<TEnum>(IReadOnlyList<TEnum> Values, Func<TEnum, string> TextSelector);
 }

--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 using Xunit;
 
@@ -28,5 +29,88 @@ public class EnumMetadataRegistryTests
         var found = EnumMetadataRegistry.TryGet<Uri>(out _, out _);
 
         Assert.False(found);
+    }
+
+    [Fact]
+    public void TryGet_UnregisteredEnum_FallsBackToReflection()
+    {
+        var found = EnumMetadataRegistry.TryGet<DayOfWeek>(out var values, out var textSelector);
+
+        Assert.True(found);
+        Assert.Equal(Enum.GetValues<DayOfWeek>(), values);
+        Assert.Equal("Monday", textSelector(DayOfWeek.Monday));
+    }
+
+    [Fact]
+    public void TryGet_RegisteredEnum_TakesPrecedenceOverFallback()
+    {
+        var values = new List<RegisteredEnum> { RegisteredEnum.Second };
+        Func<RegisteredEnum, string> textSelector = _ => "custom";
+
+        EnumMetadataRegistry.Register(values, textSelector);
+
+        var found = EnumMetadataRegistry.TryGet<RegisteredEnum>(out var retrievedValues, out var retrievedSelector);
+
+        Assert.True(found);
+        Assert.Equal(values, retrievedValues);
+        Assert.Same(textSelector, retrievedSelector);
+    }
+
+    [Fact]
+    public void CreateFallbackMetadata_UsesDisplayAttribute()
+    {
+        var metadata = EnumMetadataRegistry.CreateFallbackMetadata<AnnotatedEnum>();
+
+        Assert.Equal(new[] { AnnotatedEnum.Third, AnnotatedEnum.First, AnnotatedEnum.Second }, metadata.Values);
+        Assert.Equal("The First", metadata.TextSelector(AnnotatedEnum.First));
+        Assert.Equal("Second", metadata.TextSelector(AnnotatedEnum.Second));
+        Assert.Equal("The Third", metadata.TextSelector(AnnotatedEnum.Third));
+    }
+
+    [Fact]
+    public void SelectOptions_UnregisteredEnum_HasItems()
+    {
+        var options = new SelectOptions<FallbackEnum>
+        {
+            Message = "message"
+        };
+
+        options.EnsureOptions();
+
+        Assert.Equal(new[] { FallbackEnum.Foo, FallbackEnum.Bar }, options.Items);
+    }
+
+    [Fact]
+    public void MultiSelectOptions_UnregisteredEnum_HasItems()
+    {
+        var options = new MultiSelectOptions<FallbackEnum>
+        {
+            Message = "message"
+        };
+
+        options.EnsureOptions();
+
+        Assert.Equal(new[] { FallbackEnum.Foo, FallbackEnum.Bar }, options.Items);
+    }
+
+    public enum RegisteredEnum
+    {
+        First,
+        Second
+    }
+
+    public enum AnnotatedEnum
+    {
+        [Display(Name = "The First", Order = 2)]
+        First,
+        Second,
+        [Display(Name = "The Third", Order = 1)]
+        Third
+    }
+
+    public enum FallbackEnum
+    {
+        Foo,
+        Bar
     }
 }


### PR DESCRIPTION
## Summary

`Prompt.Select<TEnum>()` / `Prompt.MultiSelect<TEnum>()` threw `ArgumentNullException: Items` in v3.1.x when the enum type had no source-generated registration. The `EnumMetadataGenerator` only sees enum declarations in the consuming compilation, so this broke:

- BCL enums (e.g. `DayOfWeek`)
- Enums from assemblies built without the Sharprompt analyzer (NuGet libraries, non-C# projects, etc.)

This restores the v3.0 behavior by generating enum metadata at runtime via reflection when no generated registration exists, with the same `Display(Name = ..., Order = ...)` semantics as the generator. The fallback result is cached in the registry, and source-generated registrations still take precedence, so the AOT-friendly path is unchanged.

Fixes #357

## Test plan

- New unit tests covering the reflection fallback (BCL enum, `Display` attribute name/order, precedence of explicit registration, `SelectOptions`/`MultiSelectOptions` integration)
- Verified with a standalone repro (app + class library + BCL enum): all three cases now resolve items, where the BCL enum previously threw

🤖 Generated with [Claude Code](https://claude.com/claude-code)