### PR TITLE
Clamp cursor position to buffer bounds on console resize

### DIFF
--- a/src/Sharprompt/Drivers/DefaultConsoleDriver.cs
+++ b/src/Sharprompt/Drivers/DefaultConsoleDriver.cs
@@ -93,7 +93,23 @@ public sealed class DefaultConsoleDriver : IConsoleDriver
 
     public void WriteLine() => Console.WriteLine();
 
-    public void SetCursorPosition(int left, int top) => Console.SetCursorPosition(left, top);
+    public void SetCursorPosition(int left, int top)
+    {
+        // The window may have been resized after the coordinates were calculated,
+        // so clamp them to the current buffer size to avoid ArgumentOutOfRangeException.
+        left = Math.Clamp(left, 0, Console.BufferWidth - 1);
+        top = Math.Clamp(top, 0, Console.BufferHeight - 1);
+
+        try
+        {
+            Console.SetCursorPosition(left, top);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // The buffer was shrunk between the clamp and the call. Skip repositioning;
+            // the next render pass will use the updated buffer size.
+        }
+    }
 
     public bool KeyAvailable => Console.KeyAvailable;
 


### PR DESCRIPTION
## Summary

`Console.SetCursorPosition` throws `ArgumentOutOfRangeException` when the console window is shrunk between coordinate calculation and the call (e.g. reducing the window width during a prompt).

`DefaultConsoleDriver.SetCursorPosition` now clamps the coordinates to the current buffer size, and swallows the remaining race where the buffer shrinks after the clamp — the next render pass picks up the new size. Since `ClearLine` and all `OffscreenBuffer` rendering go through this method, this covers every call site.

Fixes #283

## Test plan

- Full test suite passes
- `DefaultConsoleDriver` requires a real (non-redirected) console, so this path is not unit-testable in CI; verified the clamping logic covers the coordinates computed by `RenderScope`/`OffscreenBuffer` (including negative `consoleTop` after a shrink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)