### PR TITLE
Fix unintended initial selection for value-type items and add form interaction tests

### DIFF
--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -40,7 +40,10 @@ public static class EnumMetadataRegistry
 
     internal static EnumMetadata<TEnum> CreateFallbackMetadata<TEnum>() where TEnum : notnull
     {
+        // GetFields does not guarantee ordering, so sort by MetadataToken to get
+        // the declaration order, matching the source generator semantics.
         var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
+                                   .OrderBy(field => field.MetadataToken)
                                    .Select((field, index) => (value: (TEnum)field.GetValue(null)!, index, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
                                    .ToArray();
 

--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -1,6 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
 
 namespace Sharprompt;
 
@@ -15,18 +18,51 @@ public static class EnumMetadataRegistry
 
     internal static bool TryGet<TEnum>(out IReadOnlyList<TEnum> values, out Func<TEnum, string> textSelector) where TEnum : notnull
     {
-        if (s_metadata.TryGetValue(typeof(TEnum), out var metadata))
+        if (!s_metadata.TryGetValue(typeof(TEnum), out var metadata))
         {
-            var item = (EnumMetadata<TEnum>)metadata;
-            values = item.Values;
-            textSelector = item.TextSelector;
-            return true;
+            if (!typeof(TEnum).IsEnum)
+            {
+                values = null!;
+                textSelector = null!;
+                return false;
+            }
+
+            metadata = s_metadata.GetOrAdd(typeof(TEnum), static _ => CreateFallbackMetadata<TEnum>());
         }
 
-        values = null!;
-        textSelector = null!;
-        return false;
+        var item = (EnumMetadata<TEnum>)metadata;
+
+        values = item.Values;
+        textSelector = item.TextSelector;
+
+        return true;
     }
 
-    private sealed record EnumMetadata<TEnum>(IReadOnlyList<TEnum> Values, Func<TEnum, string> TextSelector);
+    internal static EnumMetadata<TEnum> CreateFallbackMetadata<TEnum>() where TEnum : notnull
+    {
+        var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
+                                   .Select((field, index) => (value: (TEnum)field.GetValue(null)!, index, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
+                                   .ToArray();
+
+        var values = members.OrderBy(x => x.displayAttribute?.GetOrder() ?? int.MaxValue)
+                            .ThenBy(x => x.index)
+                            .Select(x => x.value)
+                            .ToArray();
+
+        var displayNames = new Dictionary<TEnum, string>();
+
+        foreach (var member in members)
+        {
+            var displayName = member.displayAttribute?.GetName();
+
+            if (displayName is not null)
+            {
+                displayNames.TryAdd(member.value, displayName);
+            }
+        }
+
+        return new EnumMetadata<TEnum>(values, value => displayNames.TryGetValue(value, out var displayName) ? displayName : value.ToString()!);
+    }
+
+    internal sealed record EnumMetadata<TEnum>(IReadOnlyList<TEnum> Values, Func<TEnum, string> TextSelector);
 }

--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Sharprompt/Internal/Paginator.cs
+++ b/src/Sharprompt/Internal/Paginator.cs
@@ -139,16 +139,18 @@ internal class Paginator<T> : IEnumerable<T> where T : notnull
 
     public void UpdatePageSize(int newPageSize)
     {
+        newPageSize = newPageSize <= 0 ? _items.Length : Math.Min(newPageSize, _items.Length);
+
         if (_pageSize == newPageSize)
         {
             return;
         }
 
-        TryGetSelectedItem(out var selectedItem);
+        var hasSelected = TryGetSelectedItem(out var selectedItem);
 
-        _pageSize = newPageSize <= 0 ? _items.Length : Math.Min(newPageSize, _items.Length);
+        _pageSize = newPageSize;
 
-        InitializeDefaults(Optional<T>.Create(selectedItem));
+        InitializeDefaults(hasSelected ? new Optional<T>(selectedItem!) : Optional<T>.Empty);
     }
 
     public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)_filteredItems).GetEnumerator();

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 using Xunit;
 
@@ -28,5 +29,88 @@ public class EnumMetadataRegistryTests
         var found = EnumMetadataRegistry.TryGet<Uri>(out _, out _);
 
         Assert.False(found);
+    }
+
+    [Fact]
+    public void TryGet_UnregisteredEnum_FallsBackToReflection()
+    {
+        var found = EnumMetadataRegistry.TryGet<DayOfWeek>(out var values, out var textSelector);
+
+        Assert.True(found);
+        Assert.Equal(Enum.GetValues<DayOfWeek>(), values);
+        Assert.Equal("Monday", textSelector(DayOfWeek.Monday));
+    }
+
+    [Fact]
+    public void TryGet_RegisteredEnum_TakesPrecedenceOverFallback()
+    {
+        var values = new List<RegisteredEnum> { RegisteredEnum.Second };
+        Func<RegisteredEnum, string> textSelector = _ => "custom";
+
+        EnumMetadataRegistry.Register(values, textSelector);
+
+        var found = EnumMetadataRegistry.TryGet<RegisteredEnum>(out var retrievedValues, out var retrievedSelector);
+
+        Assert.True(found);
+        Assert.Equal(values, retrievedValues);
+        Assert.Same(textSelector, retrievedSelector);
+    }
+
+    [Fact]
+    public void CreateFallbackMetadata_UsesDisplayAttribute()
+    {
+        var metadata = EnumMetadataRegistry.CreateFallbackMetadata<AnnotatedEnum>();
+
+        Assert.Equal(new[] { AnnotatedEnum.Third, AnnotatedEnum.First, AnnotatedEnum.Second }, metadata.Values);
+        Assert.Equal("The First", metadata.TextSelector(AnnotatedEnum.First));
+        Assert.Equal("Second", metadata.TextSelector(AnnotatedEnum.Second));
+        Assert.Equal("The Third", metadata.TextSelector(AnnotatedEnum.Third));
+    }
+
+    [Fact]
+    public void SelectOptions_UnregisteredEnum_HasItems()
+    {
+        var options = new SelectOptions<FallbackEnum>
+        {
+            Message = "message"
+        };
+
+        options.EnsureOptions();
+
+        Assert.Equal(new[] { FallbackEnum.Foo, FallbackEnum.Bar }, options.Items);
+    }
+
+    [Fact]
+    public void MultiSelectOptions_UnregisteredEnum_HasItems()
+    {
+        var options = new MultiSelectOptions<FallbackEnum>
+        {
+            Message = "message"
+        };
+
+        options.EnsureOptions();
+
+        Assert.Equal(new[] { FallbackEnum.Foo, FallbackEnum.Bar }, options.Items);
+    }
+
+    public enum RegisteredEnum
+    {
+        First,
+        Second
+    }
+
+    public enum AnnotatedEnum
+    {
+        [Display(Name = "The First", Order = 2)]
+        First,
+        Second,
+        [Display(Name = "The Third", Order = 1)]
+        Third
+    }
+
+    public enum FallbackEnum
+    {
+        Foo,
+        Bar
     }
 }

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -11,12 +11,14 @@ public class EnumMetadataRegistryTests
     [Fact]
     public void Register_And_TryGet_ReturnsRegisteredValues()
     {
-        var values = new List<string> { "A", "B", "C" };
-        Func<string, string> textSelector = x => x.ToUpperInvariant();
+        // Use a type unique to this test: the registry is a global static, so
+        // registering a common type such as string leaks into other tests.
+        var values = new List<CustomItem> { new("A"), new("B"), new("C") };
+        Func<CustomItem, string> textSelector = x => x.Value.ToUpperInvariant();
 
         EnumMetadataRegistry.Register(values, textSelector);
 
-        var found = EnumMetadataRegistry.TryGet<string>(out var retrievedValues, out var retrievedSelector);
+        var found = EnumMetadataRegistry.TryGet<CustomItem>(out var retrievedValues, out var retrievedSelector);
 
         Assert.True(found);
         Assert.Equal(values, retrievedValues);
@@ -92,6 +94,8 @@ public class EnumMetadataRegistryTests
 
         Assert.Equal(new[] { FallbackEnum.Foo, FallbackEnum.Bar }, options.Items);
     }
+
+    public sealed record CustomItem(string Value);
 
     public enum RegisteredEnum
     {

--- a/tests/Sharprompt.Tests/Forms/FakeConsoleDriver.cs
+++ b/tests/Sharprompt.Tests/Forms/FakeConsoleDriver.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/tests/Sharprompt.Tests/Forms/FakeConsoleDriver.cs
+++ b/tests/Sharprompt.Tests/Forms/FakeConsoleDriver.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Sharprompt.Drivers;
+
+namespace Sharprompt.Tests;
+
+// Scriptable console driver for form interaction tests. Keys are consumed from a queue,
+// and cursor movement is emulated just enough for OffscreenBuffer's rendering logic.
+internal sealed class FakeConsoleDriver : IConsoleDriver
+{
+    private readonly Queue<ConsoleKeyInfo> _keys = new();
+    private readonly StringBuilder _output = new();
+
+    private int _cursorLeft;
+    private int _cursorTop;
+
+    public string Output => _output.ToString();
+
+    public void EnqueueKey(ConsoleKey key, ConsoleModifiers modifiers = 0, char keyChar = '\0')
+        => _keys.Enqueue(new ConsoleKeyInfo(keyChar, key, modifiers.HasFlag(ConsoleModifiers.Shift), modifiers.HasFlag(ConsoleModifiers.Alt), modifiers.HasFlag(ConsoleModifiers.Control)));
+
+    public void EnqueueText(string text)
+    {
+        foreach (var c in text)
+        {
+            _keys.Enqueue(new ConsoleKeyInfo(c, default, false, false, false));
+        }
+    }
+
+    public void EnqueueEnter() => EnqueueKey(ConsoleKey.Enter, keyChar: '\r');
+
+    public void Dispose()
+    {
+    }
+
+    public void Beep()
+    {
+    }
+
+    public void Reset()
+    {
+    }
+
+    public void ClearLine(int top) => SetCursorPosition(0, top);
+
+    public ConsoleKeyInfo ReadKey()
+        => _keys.Count > 0 ? _keys.Dequeue() : throw new InvalidOperationException("No more keys are queued. The form is still waiting for input.");
+
+    public void Write(string value, ConsoleColor color)
+    {
+        _output.Append(value);
+        _cursorLeft += value.Length;
+    }
+
+    public void WriteLine()
+    {
+        _output.Append('\n');
+        _cursorLeft = 0;
+        _cursorTop++;
+    }
+
+    public void SetCursorPosition(int left, int top)
+    {
+        _cursorLeft = left;
+        _cursorTop = top;
+    }
+
+    public bool KeyAvailable => _keys.Count > 0;
+
+    public bool CursorVisible { get; set; } = true;
+
+    public int CursorLeft => _cursorLeft;
+
+    public int CursorTop => _cursorTop;
+
+    public int BufferWidth => 80;
+
+    public int BufferHeight => 300;
+
+    public int WindowWidth => 80;
+
+    public int WindowHeight => 300;
+
+    public Action CancellationCallback { get; set; } = () => { };
+}

--- a/tests/Sharprompt.Tests/Forms/FakeConsoleDriver.cs
+++ b/tests/Sharprompt.Tests/Forms/FakeConsoleDriver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 
 using Sharprompt.Drivers;
+using Sharprompt.Internal;
 
 namespace Sharprompt.Tests;
 
@@ -51,7 +52,22 @@ internal sealed class FakeConsoleDriver : IConsoleDriver
     public void Write(string value, ConsoleColor color)
     {
         _output.Append(value);
-        _cursorLeft += value.Length;
+
+        // Emulate deferred line wrapping: the cursor stays past the end of a full
+        // line and wraps only when the next character is written, which is the
+        // behavior OffscreenBuffer's cursor math assumes.
+        foreach (var rune in value.EnumerateRunes())
+        {
+            var width = rune.ToString().GetWidth();
+
+            if (_cursorLeft + width > BufferWidth)
+            {
+                _cursorLeft = 0;
+                _cursorTop++;
+            }
+
+            _cursorLeft += width;
+        }
     }
 
     public void WriteLine()

--- a/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
+++ b/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Sharprompt.Forms;

--- a/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
+++ b/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
@@ -218,6 +218,26 @@ public class FormInteractionTests
     }
 
     [Fact]
+    public void SelectForm_MessageLongerThanBufferWidth_StillWorks()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<string>
+        {
+            Message = new string('x', 200),
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        Assert.Equal("banana", form.Start());
+    }
+
+    [Fact]
     public void SelectForm_RendersMessageAndItems()
     {
         var (driver, configuration) = CreateTestContext();

--- a/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
+++ b/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+
+using Sharprompt.Forms;
+
+using Xunit;
+
+namespace Sharprompt.Tests;
+
+public class FormInteractionTests
+{
+    private static (FakeConsoleDriver driver, PromptConfiguration configuration) CreateTestContext()
+    {
+        var driver = new FakeConsoleDriver();
+
+        var configuration = new PromptConfiguration
+        {
+            ThrowExceptionOnCancel = true,
+            ConsoleDriverFactory = () => driver
+        };
+
+        return (driver, configuration);
+    }
+
+    [Fact]
+    public void SelectForm_ArrowKeysAndEnter_ReturnsSelectedItem()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<string>
+        {
+            Message = "message",
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        Assert.Equal("banana", form.Start());
+    }
+
+    [Fact]
+    public void SelectForm_FilterKeyword_NarrowsToSingleItem()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueText("che");
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<string>
+        {
+            Message = "message",
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        Assert.Equal("cherry", form.Start());
+    }
+
+    [Fact]
+    public void SelectForm_UnregisteredEnum_WorksEndToEnd()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<DayOfWeek>
+        {
+            Message = "message"
+        };
+
+        using var form = new SelectForm<DayOfWeek>(options, configuration);
+
+        Assert.Equal(DayOfWeek.Monday, form.Start());
+    }
+
+    [Fact]
+    public void SelectForm_EnterWithoutSelection_ShowsErrorAndContinues()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueEnter();
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<string>
+        {
+            Message = "message",
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        Assert.Equal("apple", form.Start());
+    }
+
+    [Fact]
+    public void MultiSelectForm_SpacebarToggle_ReturnsCheckedItems()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueKey(ConsoleKey.Spacebar, keyChar: ' ');
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueKey(ConsoleKey.Spacebar, keyChar: ' ');
+        driver.EnqueueEnter();
+
+        var options = new MultiSelectOptions<string>
+        {
+            Message = "message",
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new MultiSelectForm<string>(options, configuration);
+
+        Assert.Equal(new[] { "apple", "banana" }, form.Start());
+    }
+
+    [Fact]
+    public void InputForm_TypedText_ReturnsConvertedValue()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueText("42");
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<int>
+        {
+            Message = "message"
+        };
+
+        using var form = new InputForm<int>(options, configuration);
+
+        Assert.Equal(42, form.Start());
+    }
+
+    [Fact]
+    public void InputForm_EmptyInputWithDefaultValue_ReturnsDefaultValue()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<int>
+        {
+            Message = "message",
+            DefaultValue = 5
+        };
+
+        using var form = new InputForm<int>(options, configuration);
+
+        Assert.Equal(5, form.Start());
+    }
+
+    [Fact]
+    public void InputForm_InvalidInput_ShowsErrorAndContinues()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueText("abc");
+        driver.EnqueueEnter();
+        driver.EnqueueKey(ConsoleKey.Backspace);
+        driver.EnqueueKey(ConsoleKey.Backspace);
+        driver.EnqueueKey(ConsoleKey.Backspace);
+        driver.EnqueueText("123");
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<int>
+        {
+            Message = "message"
+        };
+
+        using var form = new InputForm<int>(options, configuration);
+
+        Assert.Equal(123, form.Start());
+    }
+
+    [Fact]
+    public void ConfirmForm_EmptyInputWithDefaultValue_ReturnsDefaultValue()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueEnter();
+
+        var options = new ConfirmOptions
+        {
+            Message = "message",
+            DefaultValue = true
+        };
+
+        using var form = new ConfirmForm(options, configuration);
+
+        Assert.True(form.Start());
+    }
+
+    [Fact]
+    public void Escape_ThrowsPromptCanceledException()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.Escape);
+
+        var options = new SelectOptions<string>
+        {
+            Message = "message",
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        Assert.Throws<PromptCanceledException>(() => form.Start());
+    }
+
+    [Fact]
+    public void SelectForm_RendersMessageAndItems()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.DownArrow);
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<string>
+        {
+            Message = "Pick a fruit",
+            Items = ["apple", "banana"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        form.Start();
+
+        Assert.Contains("Pick a fruit", driver.Output);
+        Assert.Contains("apple", driver.Output);
+        Assert.Contains("banana", driver.Output);
+    }
+}

--- a/tests/Sharprompt.Tests/Internal/PaginatorTests.cs
+++ b/tests/Sharprompt.Tests/Internal/PaginatorTests.cs
@@ -239,6 +239,33 @@ public class PaginatorTests
     }
 
     [Fact]
+    public void UpdatePageSize_WithoutSelection_KeepsValueTypeItemUnselected()
+    {
+        var paginator = new Paginator<int>(Enumerable.Range(0, 5), 5, Optional<int>.Empty, x => x.ToString());
+
+        paginator.UpdatePageSize(3);
+
+        var selected = paginator.TryGetSelectedItem(out _);
+
+        Assert.False(selected);
+    }
+
+    [Fact]
+    public void UpdatePageSize_LargerThanItemCount_DoesNotReinitialize()
+    {
+        var paginator = new Paginator<int>(Enumerable.Range(0, 5), int.MaxValue, Optional<int>.Empty, x => x.ToString());
+
+        paginator.NextItem();
+        paginator.NextItem();
+        paginator.UpdatePageSize(100);
+
+        var selected = paginator.TryGetSelectedItem(out var selectedItem);
+
+        Assert.True(selected);
+        Assert.Equal(1, selectedItem);
+    }
+
+    [Fact]
     public void GetEnumerator()
     {
         var paginator = new Paginator<int>(Enumerable.Range(0, 5), 5, Optional<int>.Empty, x => x.ToString());


### PR DESCRIPTION
## Summary

Two changes in `Paginator<T>.UpdatePageSize`:

- It ignored the boolean result of `TryGetSelectedItem` and reused the `out` parameter, so for value-type items (e.g. enum `Select`) the item equal to `default(T)` was silently pre-selected on the first render — inconsistent with reference-type items, which start unselected.
- It compared the requested page size against the clamped stored value, so whenever the item count was smaller than the requested size (the common `PageSize = int.MaxValue` default), the early return never hit and the paginator was fully reinitialized on every render.

This PR also adds a form interaction test harness: a scriptable `FakeConsoleDriver` that feeds queued key input through `IConsoleDriver`, plus tests driving `SelectForm` / `MultiSelectForm` / `InputForm` / `ConfirmForm` end to end (arrow-key selection, filtering, validation errors, default values, Escape cancellation, and the enum fallback). These tests are what surfaced the `UpdatePageSize` bug.

## Notes

**Stacked on #372** — the end-to-end enum test requires the reflection fallback. Merge #372 first; this PR targets its branch and should retarget to `master` once it lands.

## Test plan

- 2 new `Paginator` unit tests covering both regressions
- 11 new form interaction tests
- Full suite: 323 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)