### PR TITLE
Handle Ctrl+V and Shift+Insert paste from the clipboard

### DIFF
--- a/src/Sharprompt/Forms/FormBase.cs
+++ b/src/Sharprompt/Forms/FormBase.cs
@@ -22,7 +22,9 @@ internal abstract class FormBase<T> : IDisposable
 
         KeyHandlerMaps = new()
         {
-            [new ConsoleKeyBinding(ConsoleKey.Escape)] = HandleEscape
+            [new ConsoleKeyBinding(ConsoleKey.Escape)] = HandleEscape,
+            [new ConsoleKeyBinding(ConsoleKey.V, ConsoleModifiers.Control)] = HandlePaste,
+            [new ConsoleKeyBinding(ConsoleKey.Insert, ConsoleModifiers.Shift)] = HandlePaste
         };
     }
 
@@ -148,5 +150,29 @@ internal abstract class FormBase<T> : IDisposable
         CancellationHandler();
 
         return true;
+    }
+
+    private bool HandlePaste()
+    {
+        // With TreatControlCAsInput enabled, the legacy Windows console no longer
+        // handles Ctrl+V itself, so the key arrives here as a raw input record.
+        var text = _configuration.ClipboardTextProvider();
+
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var handled = false;
+
+        foreach (var c in text)
+        {
+            if (!char.IsControl(c))
+            {
+                handled |= HandleTextInput(new ConsoleKeyInfo(c, default, false, false, false));
+            }
+        }
+
+        return handled;
     }
 }

--- a/src/Sharprompt/Internal/ClipboardHelper.cs
+++ b/src/Sharprompt/Internal/ClipboardHelper.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Sharprompt.Internal;
+
+internal static class ClipboardHelper
+{
+    public static string? GetText()
+    {
+        // Only Windows needs to read the clipboard directly: enabling
+        // TreatControlCAsInput disables the legacy console's own Ctrl+V paste
+        // handling, so the key arrives as a raw ^V input record. Other platforms
+        // rely on the terminal emulator to translate paste into key input.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return null;
+        }
+
+        if (!NativeMethods.IsClipboardFormatAvailable(NativeMethods.CF_UNICODETEXT) || !NativeMethods.OpenClipboard(IntPtr.Zero))
+        {
+            return null;
+        }
+
+        try
+        {
+            var hMem = NativeMethods.GetClipboardData(NativeMethods.CF_UNICODETEXT);
+
+            if (hMem == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var pointer = NativeMethods.GlobalLock(hMem);
+
+            if (pointer == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Marshal.PtrToStringUni(pointer);
+            }
+            finally
+            {
+                NativeMethods.GlobalUnlock(hMem);
+            }
+        }
+        finally
+        {
+            NativeMethods.CloseClipboard();
+        }
+    }
+}

--- a/src/Sharprompt/Internal/NativeMethods.cs
+++ b/src/Sharprompt/Internal/NativeMethods.cs
@@ -11,6 +11,9 @@ internal static class NativeMethods
     // ReSharper disable once InconsistentNaming
     public const int ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
 
+    // ReSharper disable once InconsistentNaming
+    public const uint CF_UNICODETEXT = 13;
+
     [DllImport("kernel32.dll")]
     public static extern IntPtr GetStdHandle(int nStdHandle);
 
@@ -19,4 +22,22 @@ internal static class NativeMethods
 
     [DllImport("kernel32.dll")]
     public static extern bool SetConsoleMode(IntPtr hConsoleHandle, int dwMode);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsClipboardFormatAvailable(uint format);
+
+    [DllImport("user32.dll")]
+    public static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetClipboardData(uint uFormat);
+
+    [DllImport("user32.dll")]
+    public static extern bool CloseClipboard();
+
+    [DllImport("kernel32.dll")]
+    public static extern IntPtr GlobalLock(IntPtr hMem);
+
+    [DllImport("kernel32.dll")]
+    public static extern bool GlobalUnlock(IntPtr hMem);
 }

--- a/src/Sharprompt/PromptConfiguration.cs
+++ b/src/Sharprompt/PromptConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using Sharprompt.Drivers;
+using Sharprompt.Internal;
 
 namespace Sharprompt;
 
@@ -17,6 +18,18 @@ public class PromptConfiguration
         {
             ArgumentNullException.ThrowIfNull(value);
             _consoleDriverFactory = value;
+        }
+    }
+
+    private Func<string?> _clipboardTextProvider = ClipboardHelper.GetText;
+
+    public Func<string?> ClipboardTextProvider
+    {
+        get => _clipboardTextProvider;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _clipboardTextProvider = value;
         }
     }
 

--- a/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
+++ b/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
@@ -200,6 +200,88 @@ public class FormInteractionTests
     }
 
     [Fact]
+    public void InputForm_CtrlV_PastesClipboardText()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        configuration.ClipboardTextProvider = () => "pasted";
+
+        driver.EnqueueKey(ConsoleKey.V, ConsoleModifiers.Control, '\x16');
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<string>
+        {
+            Message = "message"
+        };
+
+        using var form = new InputForm<string>(options, configuration);
+
+        Assert.Equal("pasted", form.Start());
+    }
+
+    [Fact]
+    public void InputForm_Paste_StripsControlCharacters()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        configuration.ClipboardTextProvider = () => "ab\r\ncd";
+
+        driver.EnqueueKey(ConsoleKey.V, ConsoleModifiers.Control, '\x16');
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<string>
+        {
+            Message = "message"
+        };
+
+        using var form = new InputForm<string>(options, configuration);
+
+        Assert.Equal("abcd", form.Start());
+    }
+
+    [Fact]
+    public void InputForm_PasteWithEmptyClipboard_KeepsAcceptingInput()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        configuration.ClipboardTextProvider = () => null;
+
+        driver.EnqueueKey(ConsoleKey.V, ConsoleModifiers.Control, '\x16');
+        driver.EnqueueText("ok");
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<string>
+        {
+            Message = "message"
+        };
+
+        using var form = new InputForm<string>(options, configuration);
+
+        Assert.Equal("ok", form.Start());
+    }
+
+    [Fact]
+    public void SelectForm_ShiftInsert_PastesIntoFilter()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        configuration.ClipboardTextProvider = () => "che";
+
+        driver.EnqueueKey(ConsoleKey.Insert, ConsoleModifiers.Shift);
+        driver.EnqueueEnter();
+
+        var options = new SelectOptions<string>
+        {
+            Message = "message",
+            Items = ["apple", "banana", "cherry"]
+        };
+
+        using var form = new SelectForm<string>(options, configuration);
+
+        Assert.Equal("cherry", form.Start());
+    }
+
+    [Fact]
     public void Escape_ThrowsPromptCanceledException()
     {
         var (driver, configuration) = CreateTestContext();


### PR DESCRIPTION
## Summary

Since v2.3.3, enabling `TreatControlCAsInput` disables the legacy Windows console's built-in Ctrl+V paste handling, so pressing Ctrl+V delivers a raw `^V` input record to the prompt, which just beeps (Windows Terminal is unaffected because it handles paste itself — which is why this was hard to reproduce).

`FormBase` now binds **Ctrl+V** and **Shift+Insert** to a paste handler that reads the clipboard (Win32 `CF_UNICODETEXT`) and routes each character through `HandleTextInput`, so text input, password input, and select/multiselect filtering all accept pasted text. Control characters (e.g. newlines) are stripped.

Clipboard access is exposed as `PromptConfiguration.ClipboardTextProvider` so it can be replaced by consumers and stubbed in tests. On non-Windows platforms the default provider returns `null` (terminal emulators translate paste into regular key input there), and an empty/unavailable clipboard falls back to the existing beep behavior.

Fixes #237

## Test plan

- 4 new form interaction tests: Ctrl+V into `InputForm`, control-character stripping, empty-clipboard fallback, Shift+Insert into `SelectForm` filtering
- Win32 clipboard read verified on a real Windows machine (`Set-Clipboard` → `ClipboardHelper.GetText()` round-trip)
- Full suite: 328 passed, `dotnet format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)