### PR TITLE
Deduplicate aliased enum values in generated metadata

### DIFF
--- a/src/Sharprompt.SourceGenerator/EnumMetadataGenerator.cs
+++ b/src/Sharprompt.SourceGenerator/EnumMetadataGenerator.cs
@@ -42,9 +42,14 @@ public sealed class EnumMetadataGenerator : IIncrementalGenerator
 
     private static string GenerateSource(INamedTypeSymbol enumSymbol)
     {
+        // Deduplicate aliased members (multiple names sharing the same constant
+        // value) keeping the first declaration, since they are indistinguishable
+        // at runtime and duplicate switch arms do not compile (CS8510).
         var members = enumSymbol.GetMembers()
             .OfType<IFieldSymbol>()
             .Where(field => field.HasConstantValue)
+            .GroupBy(field => field.ConstantValue)
+            .Select(group => group.First())
             .Select((field, index) => AnalyzeMember(enumSymbol, field, index))
             .ToArray();
 

--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -41,10 +41,12 @@ public static class EnumMetadataRegistry
     internal static EnumMetadata<TEnum> CreateFallbackMetadata<TEnum>() where TEnum : notnull
     {
         // GetFields does not guarantee ordering, so sort by MetadataToken to get
-        // the declaration order, matching the source generator semantics.
+        // the declaration order, matching the source generator semantics. Aliased
+        // members sharing the same constant value keep the first declaration only.
         var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
                                    .OrderBy(field => field.MetadataToken)
                                    .Select((field, index) => (value: (TEnum)field.GetValue(null)!, index, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
+                                   .DistinctBy(x => x.value)
                                    .ToArray();
 
         var values = members.OrderBy(x => x.displayAttribute?.GetOrder() ?? int.MaxValue)

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -70,6 +70,16 @@ public class EnumMetadataRegistryTests
     }
 
     [Fact]
+    public void CreateFallbackMetadata_AliasedValues_KeepsFirstDeclaration()
+    {
+        var metadata = EnumMetadataRegistry.CreateFallbackMetadata<AliasedEnum>();
+
+        Assert.Equal(new[] { AliasedEnum.None, AliasedEnum.Value }, metadata.Values);
+        Assert.Equal("None", metadata.TextSelector(AliasedEnum.None));
+        Assert.Equal("None", metadata.TextSelector(AliasedEnum.Default));
+    }
+
+    [Fact]
     public void SelectOptions_UnregisteredEnum_HasItems()
     {
         var options = new SelectOptions<FallbackEnum>
@@ -110,6 +120,13 @@ public class EnumMetadataRegistryTests
         Second,
         [Display(Name = "The Third", Order = 1)]
         Third
+    }
+
+    public enum AliasedEnum
+    {
+        None = 0,
+        Default = 0,
+        Value = 1
     }
 
     public enum FallbackEnum


### PR DESCRIPTION
## Summary

An enum with aliased members — multiple names sharing the same constant value, e.g.

```csharp
public enum AliasEnum
{
    None = 0,
    Default = 0,
    Value = 1
}
```

made `EnumMetadataGenerator` emit a switch expression with duplicate constant patterns, **breaking the consuming project's build** with `CS8510: The pattern is unreachable` in the generated file.

Members are now deduplicated by constant value keeping the first declaration (aliases are indistinguishable at runtime anyway), for both the generated values array and the display-name switch. The reflection fallback in `EnumMetadataRegistry` applies the same semantics so both paths behave identically.

Note: this was also broken in v3.0.x, where `EnumHelper` threw `ArgumentException` at runtime on the duplicate dictionary key — so this has never worked, it just fails earlier (at compile time) in v3.1.

## Test plan

- Verified with a standalone consumer project: the alias enum previously failed to compile (CS8510 in `*.EnumMetadata.g.cs`); after the fix it builds and resolves `Items = [None, Value]` with `Default` labeled `None`
- New unit test for the reflection fallback dedup semantics
- Full suite: 325 passed, `dotnet format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)