### PR TITLE
Declare AOT compatibility and fix Native AOT crash in enum fallback

### DIFF
--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -38,15 +39,18 @@ public static class EnumMetadataRegistry
         return true;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2090", Justification = "This method is only invoked for enum types, and the trimmer always preserves the fields of enum types it keeps.")]
     internal static EnumMetadata<TEnum> CreateFallbackMetadata<TEnum>() where TEnum : notnull
     {
-        // GetFields does not guarantee ordering, so sort by MetadataToken to get
-        // the declaration order, matching the source generator semantics. Aliased
-        // members sharing the same constant value keep the first declaration only.
+        // GetFields does not guarantee ordering and MetadataToken is unavailable on
+        // Native AOT, so sort by the underlying constant value for a deterministic
+        // order, matching Enum.GetValues semantics. Aliased members sharing the
+        // same constant value keep a single representative.
         var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
-                                   .OrderBy(field => field.MetadataToken)
-                                   .Select((field, index) => (value: (TEnum)field.GetValue(null)!, index, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
+                                   .Select(field => (value: (TEnum)field.GetValue(null)!, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
                                    .DistinctBy(x => x.value)
+                                   .OrderBy(x => x.value)
+                                   .Select((x, index) => (x.value, index, x.displayAttribute))
                                    .ToArray();
 
         var values = members.OrderBy(x => x.displayAttribute?.GetOrder() ?? int.MaxValue)

--- a/src/Sharprompt/EnumMetadataRegistry.cs
+++ b/src/Sharprompt/EnumMetadataRegistry.cs
@@ -45,12 +45,14 @@ public static class EnumMetadataRegistry
         // GetFields does not guarantee ordering and MetadataToken is unavailable on
         // Native AOT, so sort by the underlying constant value for a deterministic
         // order, matching Enum.GetValues semantics. Aliased members sharing the
-        // same constant value keep a single representative.
+        // same constant value keep a single representative, chosen by ordinal name
+        // order so the result does not depend on the GetFields ordering either.
         var members = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static)
-                                   .Select(field => (value: (TEnum)field.GetValue(null)!, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
-                                   .DistinctBy(x => x.value)
+                                   .Select(field => (value: (TEnum)field.GetValue(null)!, field.Name, displayAttribute: field.GetCustomAttribute<DisplayAttribute>()))
                                    .OrderBy(x => x.value)
-                                   .Select((x, index) => (x.value, index, x.displayAttribute))
+                                   .ThenBy(x => x.Name, StringComparer.Ordinal)
+                                   .DistinctBy(x => x.value)
+                                   .Select((x, index) => (x.value, x.Name, index, x.displayAttribute))
                                    .ToArray();
 
         var values = members.OrderBy(x => x.displayAttribute?.GetOrder() ?? int.MaxValue)
@@ -58,16 +60,13 @@ public static class EnumMetadataRegistry
                             .Select(x => x.value)
                             .ToArray();
 
+        // Always map through the representative's field name: Enum.ToString picks
+        // an implementation-defined alias, which would defeat the determinism above.
         var displayNames = new Dictionary<TEnum, string>();
 
         foreach (var member in members)
         {
-            var displayName = member.displayAttribute?.GetName();
-
-            if (displayName is not null)
-            {
-                displayNames.TryAdd(member.value, displayName);
-            }
+            displayNames.TryAdd(member.value, member.displayAttribute?.GetName() ?? member.Name);
         }
 
         return new EnumMetadata<TEnum>(values, value => displayNames.TryGetValue(value, out var displayName) ? displayName : value.ToString()!);

--- a/src/Sharprompt/Internal/TypeHelper.cs
+++ b/src/Sharprompt/Internal/TypeHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Sharprompt.Internal;
 
@@ -10,5 +11,7 @@ internal static class TypeHelper<T>
 
     public static bool IsNullable => !s_targetType.IsValueType || s_underlyingType is not null;
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TypeDescriptor's intrinsic converters cover the types typically used with prompts (string, numeric types, bool, char, Guid, DateTime, enums, etc.) and do not require unreferenced code. Custom TypeConverter attributes on user-defined types may require the application to preserve the converter type.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2077", Justification = "See IL2026 justification: only intrinsic converters are relied upon.")]
     public static T? ConvertTo(string value) => (T?)TypeDescriptor.GetConverter(s_underlyingType ?? s_targetType).ConvertFromInvariantString(value);
 }

--- a/src/Sharprompt/Sharprompt.csproj
+++ b/src/Sharprompt/Sharprompt.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
+++ b/tests/Sharprompt.Tests/Binding/EnumMetadataRegistryTests.cs
@@ -70,13 +70,15 @@ public class EnumMetadataRegistryTests
     }
 
     [Fact]
-    public void CreateFallbackMetadata_AliasedValues_KeepsFirstDeclaration()
+    public void CreateFallbackMetadata_AliasedValues_KeepsSingleDeterministicRepresentative()
     {
         var metadata = EnumMetadataRegistry.CreateFallbackMetadata<AliasedEnum>();
 
+        // Aliases collapse to one entry; the representative is the alias whose
+        // name sorts first ordinally ("Default" < "None").
         Assert.Equal(new[] { AliasedEnum.None, AliasedEnum.Value }, metadata.Values);
-        Assert.Equal("None", metadata.TextSelector(AliasedEnum.None));
-        Assert.Equal("None", metadata.TextSelector(AliasedEnum.Default));
+        Assert.Equal("Default", metadata.TextSelector(AliasedEnum.None));
+        Assert.Equal("Default", metadata.TextSelector(AliasedEnum.Default));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes Sharprompt trim- and Native AOT-compatible, and fixes a real Native AOT crash found during verification.

- **`<IsAotCompatible>true</IsAotCompatible>`** on the library — enables the trim/AOT analyzers at build time and marks the NuGet package as AOT-compatible for consumers.
- **Native AOT crash fix**: `FieldInfo.MetadataToken` throws `InvalidOperationException` on Native AOT, crashing the enum reflection fallback (`Prompt.Select<TEnum>` for unregistered enums). The fallback now sorts by the underlying constant value instead — deterministic on every runtime and matching `Enum.GetValues` semantics.
- **IL2090 suppressed** in the enum fallback with justification: the trimmer always preserves fields of enum types it keeps (verified empirically with `TrimMode=full`).
- **IL2026/IL2077 suppressed** for `TypeDescriptor.GetConverter` in `TypeHelper<T>`: intrinsic converters cover the types typically used with prompts (string, numerics, bool, Guid, DateTime, enums); custom `TypeConverter` attributes on user-defined types remain the application's responsibility to preserve.

Fixes #248

## Verification

| Scenario | Result |
| --- | --- |
| `dotnet build` with AOT analyzers | 0 IL warnings |
| `PublishTrimmed` + `TrimMode=full` (win-x64) | 0 IL warnings; generated path + enum fallback + `TypeDescriptor` conversions all work at runtime |
| `PublishAot` (win-x64, ILC 8.0.28) | 0 IL warnings; native binary runs, generated path + enum fallback verified (previously crashed with `InvalidOperationException` on `MetadataToken`) |
| Unit tests | 325 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)