### PR TITLE
Add net10.0 target framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,19 +21,18 @@ on:
 permissions:
   contents: read
 
-env:
-  DOTNET_VERSION: 8.0.x
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-    - name: Use .NET ${{ env.DOTNET_VERSION }}
+    - name: Use .NET SDK
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - name: Build project
       run: dotnet build -c Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags: [ v* ]
 
-env:
-  DOTNET_VERSION: 8.0.x
-
 jobs:
   publish:
     permissions:
@@ -15,10 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-    - name: Use .NET ${{ env.DOTNET_VERSION }}
+    - name: Use .NET SDK
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0

--- a/src/Sharprompt/Sharprompt.csproj
+++ b/src/Sharprompt/Sharprompt.csproj
@@ -53,8 +53,8 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackSourceGenerator</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <!-- The analyzer is TFM-independent, so pack it only once even when multi-targeting. -->
-  <Target Name="_PackSourceGenerator" Condition="'$(TargetFramework)' == 'net8.0'">
+  <!-- The analyzer is TFM-independent, so pack it only once (for the first TFM) even when multi-targeting. -->
+  <Target Name="_PackSourceGenerator" Condition="'$(TargetFramework)' == '$(TargetFrameworks.Split(`;`)[0])'">
     <MSBuild Projects="..\Sharprompt.SourceGenerator\Sharprompt.SourceGenerator.csproj" Targets="GetTargetPath" RemoveProperties="TargetFramework">
       <Output TaskParameter="TargetOutputs" ItemName="_SourceGeneratorOutput" />
     </MSBuild>

--- a/src/Sharprompt/Sharprompt.csproj
+++ b/src/Sharprompt/Sharprompt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
@@ -53,7 +53,8 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackSourceGenerator</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <Target Name="_PackSourceGenerator">
+  <!-- The analyzer is TFM-independent, so pack it only once even when multi-targeting. -->
+  <Target Name="_PackSourceGenerator" Condition="'$(TargetFramework)' == 'net8.0'">
     <MSBuild Projects="..\Sharprompt.SourceGenerator\Sharprompt.SourceGenerator.csproj" Targets="GetTargetPath" RemoveProperties="TargetFramework">
       <Output TaskParameter="TargetOutputs" ItemName="_SourceGeneratorOutput" />
     </MSBuild>

--- a/tests/Sharprompt.Tests/Sharprompt.Tests.csproj
+++ b/tests/Sharprompt.Tests/Sharprompt.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Multi-targets the library and test project to **net8.0 + net10.0**.

- `Sharprompt.csproj` / `Sharprompt.Tests.csproj`: `<TargetFrameworks>net8.0;net10.0</TargetFrameworks>` — the full test suite now runs on both runtimes.
- The `_PackSourceGenerator` target is TFM-independent, so it is now conditioned to pack the analyzer only once (previously it would be added per-TFM, producing duplicate-file pack warnings).
- `build.yml` / `publish.yml`: install both the 8.0.x and 10.0.x SDKs (running the net8.0 test target requires the .NET 8 runtime; `DOTNET_VERSION` env replaced by an inline version list).

## Verification

- Build clean, 330 tests × 2 TFMs (net8.0 / net10.0) all pass
- `dotnet pack`: package contains `lib/net8.0`, `lib/net10.0` (with satellite resources), and `analyzers/dotnet/cs` exactly once — no pack warnings
- `dotnet format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)