### PR TITLE
Allow dismissing the default value to submit an empty input

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ var number = Prompt.Input<int>("Enter any number");
 Console.WriteLine($"Input = {number}");
 ```
 
-When a default value is provided, pressing <kbd>Enter</kbd> with nothing typed accepts the default. Press <kbd>Tab</kbd> to insert the default value for editing, or <kbd>Backspace</kbd> to dismiss the default so an empty value can be submitted.
+When a default value is provided, pressing <kbd>Enter</kbd> with nothing typed accepts the default. Press <kbd>Tab</kbd> to insert the default value for editing, or <kbd>Backspace</kbd> to dismiss the default — the prompt then behaves as if no default value was provided, so an empty value can be submitted (subject to the usual required check for non-nullable types and any validators).
 
 ![input](https://user-images.githubusercontent.com/1356444/62228275-50c72300-b3f8-11e9-8d51-63892e8eeaaa.gif)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ var number = Prompt.Input<int>("Enter any number");
 Console.WriteLine($"Input = {number}");
 ```
 
+When a default value is provided, pressing <kbd>Enter</kbd> with nothing typed accepts the default. Press <kbd>Tab</kbd> to insert the default value for editing, or <kbd>Backspace</kbd> to dismiss the default so an empty value can be submitted.
+
 ![input](https://user-images.githubusercontent.com/1356444/62228275-50c72300-b3f8-11e9-8d51-63892e8eeaaa.gif)
 
 ### Confirm

--- a/src/Sharprompt/Forms/InputForm.cs
+++ b/src/Sharprompt/Forms/InputForm.cs
@@ -15,10 +15,12 @@ internal class InputForm<T> : TextFormBase<T>
         _options = options;
 
         _defaultValue = Optional<T>.Create(options.DefaultValue);
+
+        KeyHandlerMaps[new ConsoleKeyBinding(ConsoleKey.Tab)] = HandleTab;
     }
 
     private readonly InputOptions<T> _options;
-    private readonly Optional<T> _defaultValue;
+    private Optional<T> _defaultValue;
 
     protected override void InputTemplate(OffscreenBuffer offscreenBuffer)
     {
@@ -82,5 +84,36 @@ internal class InputForm<T> : TextFormBase<T>
         result = default;
 
         return false;
+    }
+
+    private bool HandleTab()
+    {
+        if (!_defaultValue.HasValue || InputBuffer.Length > 0)
+        {
+            return false;
+        }
+
+        foreach (var c in _defaultValue.Value.ToString() ?? "")
+        {
+            InputBuffer.Insert(c);
+        }
+
+        _defaultValue = Optional<T>.Empty;
+
+        return true;
+    }
+
+    protected override bool HandleBackspace()
+    {
+        // Backspace with nothing typed dismisses the default value, allowing an
+        // empty submission even when a default value is provided.
+        if (InputBuffer.Length == 0 && _defaultValue.HasValue)
+        {
+            _defaultValue = Optional<T>.Empty;
+
+            return true;
+        }
+
+        return base.HandleBackspace();
     }
 }

--- a/src/Sharprompt/Forms/InputForm.cs
+++ b/src/Sharprompt/Forms/InputForm.cs
@@ -93,7 +93,9 @@ internal class InputForm<T> : TextFormBase<T>
             return false;
         }
 
-        foreach (var c in _defaultValue.Value.ToString() ?? "")
+        // Use the invariant converter so the inserted text round-trips through
+        // TypeHelper<T>.ConvertTo regardless of the current culture.
+        foreach (var c in TypeHelper<T>.ConvertToString(_defaultValue.Value))
         {
             InputBuffer.Insert(c);
         }
@@ -105,8 +107,9 @@ internal class InputForm<T> : TextFormBase<T>
 
     protected override bool HandleBackspace()
     {
-        // Backspace with nothing typed dismisses the default value, allowing an
-        // empty submission even when a default value is provided.
+        // Backspace with nothing typed dismisses the default value: Enter then
+        // behaves as if no default value was provided, so nullable types can
+        // submit an empty value while non-nullable types still require input.
         if (InputBuffer.Length == 0 && _defaultValue.HasValue)
         {
             _defaultValue = Optional<T>.Empty;

--- a/src/Sharprompt/Internal/TypeHelper.cs
+++ b/src/Sharprompt/Internal/TypeHelper.cs
@@ -14,4 +14,8 @@ internal static class TypeHelper<T>
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TypeDescriptor's intrinsic converters cover the types typically used with prompts (string, numeric types, bool, char, Guid, DateTime, enums, etc.) and do not require unreferenced code. Custom TypeConverter attributes on user-defined types may require the application to preserve the converter type.")]
     [UnconditionalSuppressMessage("Trimming", "IL2077", Justification = "See IL2026 justification: only intrinsic converters are relied upon.")]
     public static T? ConvertTo(string value) => (T?)TypeDescriptor.GetConverter(s_underlyingType ?? s_targetType).ConvertFromInvariantString(value);
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "See ConvertTo: only intrinsic converters are relied upon.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2077", Justification = "See ConvertTo: only intrinsic converters are relied upon.")]
+    public static string ConvertToString(T value) => TypeDescriptor.GetConverter(s_underlyingType ?? s_targetType).ConvertToInvariantString(value) ?? "";
 }

--- a/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
+++ b/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 using Sharprompt.Forms;
 
@@ -176,6 +177,38 @@ public class FormInteractionTests
         using var form = new InputForm<string>(options, configuration);
 
         Assert.Equal("blueberry", form.Start());
+    }
+
+    [Fact]
+    public void InputForm_Tab_RoundTripsDefaultValueUnderNonInvariantCulture()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            // de-DE formats 1.5 as "1,5" via ToString, which ConvertFromInvariantString
+            // cannot parse back; the inserted text must use the invariant format.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var (driver, configuration) = CreateTestContext();
+
+            driver.EnqueueKey(ConsoleKey.Tab, keyChar: '\t');
+            driver.EnqueueEnter();
+
+            var options = new InputOptions<double>
+            {
+                Message = "message",
+                DefaultValue = 1.5
+            };
+
+            using var form = new InputForm<double>(options, configuration);
+
+            Assert.Equal(1.5, form.Start());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
     }
 
     [Fact]

--- a/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
+++ b/tests/Sharprompt.Tests/Forms/FormInteractionTests.cs
@@ -159,6 +159,86 @@ public class FormInteractionTests
     }
 
     [Fact]
+    public void InputForm_Tab_InsertsDefaultValueForEditing()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.Tab, keyChar: '\t');
+        driver.EnqueueText("berry");
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<string>
+        {
+            Message = "message",
+            DefaultValue = "blue"
+        };
+
+        using var form = new InputForm<string>(options, configuration);
+
+        Assert.Equal("blueberry", form.Start());
+    }
+
+    [Fact]
+    public void InputForm_TabWithTypedText_DoesNothing()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueText("red");
+        driver.EnqueueKey(ConsoleKey.Tab, keyChar: '\t');
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<string>
+        {
+            Message = "message",
+            DefaultValue = "blue"
+        };
+
+        using var form = new InputForm<string>(options, configuration);
+
+        Assert.Equal("red", form.Start());
+    }
+
+    [Fact]
+    public void InputForm_BackspaceOnEmptyBuffer_DismissesDefaultValue()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.Backspace);
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<string>
+        {
+            Message = "message",
+            DefaultValue = "blue"
+        };
+
+        using var form = new InputForm<string>(options, configuration);
+
+        Assert.Null(form.Start());
+    }
+
+    [Fact]
+    public void InputForm_DismissedDefaultValue_RequiresInputForNonNullable()
+    {
+        var (driver, configuration) = CreateTestContext();
+
+        driver.EnqueueKey(ConsoleKey.Backspace);
+        driver.EnqueueEnter();
+        driver.EnqueueText("7");
+        driver.EnqueueEnter();
+
+        var options = new InputOptions<int>
+        {
+            Message = "message",
+            DefaultValue = 5
+        };
+
+        using var form = new InputForm<int>(options, configuration);
+
+        Assert.Equal(7, form.Start());
+    }
+
+    [Fact]
     public void InputForm_InvalidInput_ShowsErrorAndContinues()
     {
         var (driver, configuration) = CreateTestContext();


### PR DESCRIPTION
## Summary

Resolves the long-standing limitation that `Prompt.Input<T>` with a default value could never return an empty result — Enter on empty input always returned the default (#297).

This adopts the **Inquirer-compatible interaction** (the de-facto standard across prompt libraries — [`@inquirer/input`](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/input) `prefill: 'tab'` and [terkelg/prompts](https://github.com/terkelg/prompts) both use it):

- **<kbd>Tab</kbd>** inserts the default value into the input buffer for editing
- **<kbd>Backspace</kbd> with nothing typed** dismisses the default value (the hint disappears); pressing Enter afterwards submits an empty value, subject to the usual non-nullable check and validators

No new API is introduced, and the default behavior is fully preserved: Enter on empty input still accepts the default. Both keys previously just beeped in these states, so this is effectively non-breaking.

For reference, Spectre.Console has the same limitation unresolved (`DefaultValue` short-circuits before `AllowEmpty`), and the stale external PR #300 proposed the same Tab interaction behind an opt-in flag — this implementation makes the flag unnecessary.

Fixes #297
Closes #300

## Test plan

- 4 new interaction tests: Tab inserts default for editing (`blue` + `berry` → `blueberry`), Tab with typed text is a no-op, Backspace dismisses the default (empty submission returns null), dismissed default still enforces required input for non-nullable types
- Full suite: 334 passed, `dotnet format` clean
- README updated with the key behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)